### PR TITLE
feat: bootstrap Next.js app with local planner

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+*.log
+pnpm-lock.yaml
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Local Quick Planner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
 # Local Quick Planner
 
-Organize your day and projects in seconds, 100% local.
-
-## About
-
-Local Quick Planner is a tool designed to help you organize your daily tasks and project management without relying on cloud services. All your data stays on your local machine, ensuring privacy and quick access.
+Local Quick Planner is a lightweight Microsoft Planner–style board that runs entirely in your browser. All data lives in `localStorage` so your tasks stay on your machine.
 
 ## Features
+- **My Day** view with To Do, In Progress, Done columns
+- **My Tasks** Kanban board with Ideas, Backlog, In Progress, Done
+- Drag & drop powered by [dnd-kit](https://dndkit.com)
+- State management via [Zustand](https://github.com/pmndrs/zustand)
+- Export / Import JSON and clear all data
 
-🚧 Coming soon...
+## Tech Stack
+- Next.js (App Router) + React + TypeScript
+- Tailwind CSS
+- Zustand
+- dnd-kit
 
-## Getting Started
-
-🚧 Under development...
-
-## Privacy First
-
-This application is designed with privacy in mind. All your data is stored locally on your machine, giving you complete control over your information.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
+## Quick Start
+```bash
+pnpm install
+pnpm dev
+```
+Then open http://localhost:3000 in your browser.
 
 ## License
-
-🚧 License information coming soon...
+[MIT](LICENSE)

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #__next, :root {
+  height: 100%;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+'use client';
+import './globals.css';
+import type { ReactNode } from 'react';
+import Header from '../components/Header';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="bg-gray-900 text-gray-100 min-h-screen">
+        <Header />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import AddTask from '../../components/AddTask';
+import Board from '../../components/Board';
+
+export default function MyDayPage() {
+  return (
+    <main>
+      <AddTask />
+      <Board mode="my-day" />
+    </main>
+  );
+}

--- a/app/my-tasks/page.tsx
+++ b/app/my-tasks/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import AddTask from '../../components/AddTask';
+import Board from '../../components/Board';
+
+export default function MyTasksPage() {
+  return (
+    <main>
+      <AddTask />
+      <Board mode="kanban" />
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function IndexPage() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/my-day');
+  }, [router]);
+  return null;
+}

--- a/components/AddTask.tsx
+++ b/components/AddTask.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useState } from 'react';
+import { Plus, CalendarPlus } from 'lucide-react';
+import { useStore } from '../lib/store';
+
+export default function AddTask() {
+  const { lists, addTask } = useStore();
+  const [title, setTitle] = useState('');
+  const [listId, setListId] = useState(lists[0]?.id ?? 'ideas');
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const handleAdd = (plan: boolean) => {
+    if (!title.trim()) return;
+    addTask({ title: title.trim(), listId, plannedFor: plan ? today : undefined });
+    setTitle('');
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleAdd(false);
+      }}
+      className="flex flex-wrap gap-2 p-4"
+    >
+      <label htmlFor="task-title" className="sr-only">
+        Title
+      </label>
+      <input
+        id="task-title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="flex-1 rounded bg-gray-800 p-2 text-sm focus:ring"
+        placeholder="New task"
+      />
+      <label htmlFor="task-list" className="sr-only">
+        List
+      </label>
+      <select
+        id="task-list"
+        value={listId}
+        onChange={(e) => setListId(e.target.value)}
+        className="rounded bg-gray-800 p-2 text-sm focus:ring"
+      >
+        {lists.map((l) => (
+          <option key={l.id} value={l.id}>
+            {l.title}
+          </option>
+        ))}
+      </select>
+      <button type="submit" className="flex items-center gap-1 rounded bg-blue-600 px-3 py-2 text-sm hover:bg-blue-700 focus:ring">
+        <Plus className="h-4 w-4" /> Add
+      </button>
+      <button
+        type="button"
+        onClick={() => handleAdd(true)}
+        className="flex items-center gap-1 rounded bg-green-600 px-3 py-2 text-sm hover:bg-green-700 focus:ring"
+      >
+        <CalendarPlus className="h-4 w-4" /> + My Day
+      </button>
+    </form>
+  );
+}

--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { DndContext, closestCorners, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import { Task } from '../lib/types';
+import { useStore } from '../lib/store';
+import Column from './Column';
+
+interface BoardProps {
+  mode: 'my-day' | 'kanban';
+}
+
+export default function Board({ mode }: BoardProps) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const { tasks, lists, order, moveTask, reorderTask } = useStore();
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const columns = mode === 'my-day'
+    ? [
+        { id: 'todo', title: 'To Do' },
+        { id: 'doing', title: 'In Progress' },
+        { id: 'done', title: 'Done' },
+      ]
+    : [...lists].sort((a, b) => a.order - b.order).map((l) => ({ id: l.id, title: l.title }));
+
+  function getTasks(columnId: string): Task[] {
+    const key = mode === 'my-day' ? `day-${columnId}` : `list-${columnId}`;
+    const ids = order[key] || [];
+    return ids
+      .map((id) => tasks.find((t) => t.id === id))
+      .filter((t): t is Task => !!t)
+      .filter((t) => (mode === 'my-day' ? t.plannedFor === today : true));
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeId = active.id as string;
+    const activeContainer = active.data.current?.sortable.containerId as string;
+    const overContainer = over.data.current?.sortable.containerId as string;
+    const overIndex = over.data.current?.sortable.index as number;
+
+    if (activeContainer === overContainer) {
+      reorderTask(activeId, overContainer, overIndex, mode);
+    } else {
+      if (mode === 'my-day') {
+        moveTask(activeId, { dayStatus: overContainer as any });
+      } else {
+        moveTask(activeId, { listId: overContainer });
+      }
+      reorderTask(activeId, overContainer, overIndex, mode);
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+      <div className="flex gap-4 overflow-x-auto p-4">
+        {columns.map((col) => (
+          <Column key={col.id} id={col.id} title={col.title} tasks={getTasks(col.id)} />
+        ))}
+      </div>
+    </DndContext>
+  );
+}

--- a/components/Column.tsx
+++ b/components/Column.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { Task } from '../lib/types';
+import TaskCard from './TaskCard';
+
+interface ColumnProps {
+  id: string;
+  title: string;
+  tasks: Task[];
+}
+
+export default function Column({ id, title, tasks }: ColumnProps) {
+  return (
+    <div className="w-80 flex-shrink-0">
+      <h2 className="mb-2 text-lg font-semibold">{title}</h2>
+      <SortableContext id={id} items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+        <div className="space-y-2">
+          {tasks.map((task) => (
+            <TaskCard key={task.id} task={task} />
+          ))}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,44 @@
+'use client';
+import Link from 'next/link';
+import { Download, Upload, Trash2 } from 'lucide-react';
+import { useStore } from '../lib/store';
+
+export default function Header() {
+  const { exportData, importData, clearAll } = useStore();
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string);
+        importData(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <header className="flex items-center justify-between bg-gray-950 px-4 py-2">
+      <nav className="flex gap-4">
+        <Link href="/my-day" className="hover:underline focus:underline">My Day</Link>
+        <Link href="/my-tasks" className="hover:underline focus:underline">My Tasks</Link>
+      </nav>
+      <div className="flex items-center gap-2">
+        <button onClick={exportData} aria-label="Export" className="p-2 rounded hover:bg-gray-800 focus:bg-gray-800">
+          <Download className="h-4 w-4" />
+        </button>
+        <label aria-label="Import" className="p-2 rounded hover:bg-gray-800 focus-within:bg-gray-800 cursor-pointer">
+          <Upload className="h-4 w-4" />
+          <input type="file" accept="application/json" onChange={handleImport} className="sr-only" />
+        </label>
+        <button onClick={clearAll} aria-label="Clear all" className="p-2 rounded hover:bg-gray-800 focus:bg-gray-800">
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Check } from 'lucide-react';
+import { Task } from '../lib/types';
+import { useStore } from '../lib/store';
+
+interface Props {
+  task: Task;
+}
+
+export default function TaskCard({ task }: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: task.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  const { moveTask } = useStore();
+  const markDone = () => {
+    if (task.dayStatus !== 'done') {
+      moveTask(task.id, { dayStatus: 'done' });
+    }
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="bg-gray-800 rounded p-2 cursor-grab focus:outline-none focus:ring"
+    >
+      <div className="flex items-center justify-between">
+        <span>{task.title}</span>
+        {task.dayStatus !== 'done' && (
+          <button onClick={markDone} aria-label="Mark as done" className="text-green-400 hover:text-green-500">
+            <Check className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,19 @@
+import { PersistedState } from './types';
+
+export const STORAGE_KEY = 'localquickplanner:v1';
+
+export function saveState(state: PersistedState) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function loadState(): PersistedState | undefined {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    return JSON.parse(raw) as PersistedState;
+  } catch {
+    return;
+  }
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,132 @@
+import { create } from 'zustand';
+import { PersistedState, Task, List } from './types';
+import { loadState, saveState } from './storage';
+
+const defaultLists: List[] = [
+  { id: 'ideas', title: 'Ideas', order: 0 },
+  { id: 'backlog', title: 'Backlog', order: 1 },
+  { id: 'inprogress', title: 'In Progress', order: 2 },
+  { id: 'done', title: 'Done', order: 3 },
+];
+
+const defaultState: PersistedState = {
+  tasks: [],
+  lists: defaultLists,
+  order: {
+    'list-ideas': [],
+    'list-backlog': [],
+    'list-inprogress': [],
+    'list-done': [],
+    'day-todo': [],
+    'day-doing': [],
+    'day-done': [],
+  },
+  version: 1,
+};
+
+type Store = PersistedState & {
+  addTask: (input: { title: string; listId?: string; plannedFor?: string }) => void;
+  updateTask: (id: string, patch: Partial<Task>) => void;
+  removeTask: (id: string) => void;
+  moveTask: (id: string, update: { listId?: string; dayStatus?: 'todo' | 'doing' | 'done' }) => void;
+  reorderTask: (id: string, columnId: string, newIndex: number, scope: 'my-day' | 'kanban') => void;
+  exportData: () => void;
+  importData: (data: PersistedState) => void;
+  clearAll: () => void;
+};
+
+const persisted = loadState();
+
+export const useStore = create<Store>((set, get) => ({
+  ...(persisted ?? defaultState),
+  addTask: ({ title, listId = 'ideas', plannedFor }) => {
+    const id = crypto.randomUUID();
+    const task: Task = {
+      id,
+      title,
+      createdAt: new Date().toISOString(),
+      listId,
+      plannedFor: plannedFor ?? null,
+      dayStatus: plannedFor ? 'todo' : undefined,
+    };
+    set((state) => {
+      const newOrder = { ...state.order };
+      const listKey = `list-${listId}`;
+      newOrder[listKey] = [...(newOrder[listKey] || []), id];
+      if (task.dayStatus) {
+        const dayKey = `day-${task.dayStatus}`;
+        newOrder[dayKey] = [...(newOrder[dayKey] || []), id];
+      }
+      return { tasks: [...state.tasks, task], order: newOrder };
+    });
+    saveState(get());
+  },
+  updateTask: (id, patch) => {
+    set((state) => ({ tasks: state.tasks.map((t) => (t.id === id ? { ...t, ...patch } : t)) }));
+    saveState(get());
+  },
+  removeTask: (id) => {
+    set((state) => {
+      const newOrder = { ...state.order };
+      for (const key in newOrder) {
+        newOrder[key] = newOrder[key].filter((tid) => tid !== id);
+      }
+      return { tasks: state.tasks.filter((t) => t.id !== id), order: newOrder };
+    });
+    saveState(get());
+  },
+  moveTask: (id, update) => {
+    set((state) => {
+      const task = state.tasks.find((t) => t.id === id);
+      if (!task) return {};
+      const newOrder = { ...state.order };
+      if (update.listId && update.listId !== task.listId) {
+        const fromKey = `list-${task.listId}`;
+        const toKey = `list-${update.listId}`;
+        newOrder[fromKey] = newOrder[fromKey].filter((tid) => tid !== id);
+        newOrder[toKey] = [...(newOrder[toKey] || []), id];
+        task.listId = update.listId;
+      }
+      if (update.dayStatus && update.dayStatus !== task.dayStatus) {
+        const fromKey = task.dayStatus ? `day-${task.dayStatus}` : null;
+        const toKey = `day-${update.dayStatus}`;
+        if (fromKey) newOrder[fromKey] = newOrder[fromKey].filter((tid) => tid !== id);
+        newOrder[toKey] = [...(newOrder[toKey] || []), id];
+        task.dayStatus = update.dayStatus;
+        task.plannedFor = new Date().toISOString().slice(0, 10);
+      }
+      return { tasks: state.tasks.map((t) => (t.id === id ? task : t)), order: newOrder };
+    });
+    saveState(get());
+  },
+  reorderTask: (id, columnId, newIndex, scope) => {
+    const key = scope === 'kanban' ? `list-${columnId}` : `day-${columnId}`;
+    set((state) => {
+      const items = Array.from(state.order[key] || []);
+      const oldIndex = items.indexOf(id);
+      if (oldIndex === -1) return {};
+      items.splice(oldIndex, 1);
+      items.splice(newIndex, 0, id);
+      return { order: { ...state.order, [key]: items } };
+    });
+    saveState(get());
+  },
+  exportData: () => {
+    const data = JSON.stringify(get(), null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'localquickplanner.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  },
+  importData: (data) => {
+    set(() => data);
+    saveState(data);
+  },
+  clearAll: () => {
+    set(() => defaultState);
+    saveState(defaultState);
+  },
+}));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,21 @@
+export type Task = {
+  id: string;
+  title: string;
+  description?: string;
+  createdAt: string;
+  dueDate?: string | null;
+  priority?: 'low' | 'med' | 'high';
+  tags?: string[];
+  listId: string;
+  plannedFor: string | null;
+  dayStatus?: 'todo' | 'doing' | 'done';
+};
+
+export type List = { id: string; title: string; order: number };
+
+export type PersistedState = {
+  tasks: Task[];
+  lists: List[];
+  order: Record<string, string[]>;
+  version: number;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "local-quick-planner",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1",
+    "framer-motion": "^11.0.0",
+    "lucide-react": "^0.339.0",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "24.2.1",
+    "@types/react": "19.1.9",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="7" height="18" rx="2" ry="2"/>
+  <rect x="14" y="3" width="7" height="7" rx="2" ry="2"/>
+  <rect x="14" y="14" width="7" height="7" rx="2" ry="2"/>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2020"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js App Router project with Tailwind CSS
- add Zustand store with localStorage persistence and default lists
- implement client-side Kanban and My Day boards with dnd-kit drag & drop

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68981dbf75b0832c9fbbe824804c8cfa