### PR TITLE
Implement editable backlog task list

### DIFF
--- a/app/my-tasks/page.tsx
+++ b/app/my-tasks/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 import AddTask from '../../components/AddTask';
-import Board from '../../components/Board';
+import TaskList from '../../components/TaskList';
 
 export default function MyTasksPage() {
   return (
     <main>
       <AddTask />
-      <Board mode="kanban" />
+      <TaskList />
     </main>
   );
 }

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { CalendarPlus, CalendarX } from 'lucide-react';
+import { Task } from '../lib/types';
+import { useStore } from '../lib/store';
+
+interface Props {
+  task: Task;
+}
+
+export default function TaskItem({ task }: Props) {
+  const { updateTask, toggleMyDay } = useStore();
+  const [title, setTitle] = useState(task.title);
+
+  useEffect(() => {
+    setTitle(task.title);
+  }, [task.title]);
+
+  const saveTitle = () => {
+    const trimmed = title.trim();
+    if (trimmed && trimmed !== task.title) {
+      updateTask(task.id, { title: trimmed });
+    } else {
+      setTitle(task.title);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded bg-gray-800 p-2">
+      <input
+        className="flex-1 rounded bg-transparent px-1 focus:ring"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        onBlur={saveTitle}
+      />
+      <select
+        value={task.priority ?? ''}
+        onChange={e =>
+          updateTask(task.id, {
+            priority: e.target.value as Task['priority'],
+          })
+        }
+        className="rounded bg-gray-700 p-1 text-sm focus:ring"
+      >
+        <option value="">-</option>
+        <option value="low">Low</option>
+        <option value="med">Medium</option>
+        <option value="high">High</option>
+      </select>
+      <button
+        onClick={() => toggleMyDay(task.id)}
+        aria-label={task.plannedFor ? 'Remove from My Day' : 'Add to My Day'}
+        className="rounded bg-blue-600 p-1 text-white hover:bg-blue-700 focus:ring"
+      >
+        {task.plannedFor ? (
+          <CalendarX className="h-4 w-4" />
+        ) : (
+          <CalendarPlus className="h-4 w-4" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -1,0 +1,23 @@
+'use client';
+import TaskItem from './TaskItem';
+import { useStore } from '../lib/store';
+
+export default function TaskList() {
+  const { tasks } = useStore();
+  const sorted = [...tasks].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  return (
+    <div className="space-y-2 p-4">
+      {sorted.map(task => (
+        <TaskItem
+          key={task.id}
+          task={task}
+        />
+      ))}
+      {sorted.length === 0 && (
+        <p className="text-center text-sm text-gray-400">No tasks</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace kanban board in My Tasks with backlog-style list
- Allow editing task titles, priorities, and toggling My Day inclusion
- Add store action for adding or removing tasks from My Day

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx next lint --file app/my-tasks/page.tsx --file components/TaskItem.tsx --file components/TaskList.tsx --file lib/store.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ada1e13d0832c82c9e9499a30b0b4