### PR TITLE
Allow moving My Day tasks between columns

### DIFF
--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -1,5 +1,12 @@
 'use client';
-import { DndContext, closestCorners, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import {
+  DndContext,
+  closestCorners,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
 import { Task } from '../lib/types';
 import { useStore } from '../lib/store';
 import Column from './Column';
@@ -9,26 +16,31 @@ interface BoardProps {
 }
 
 export default function Board({ mode }: BoardProps) {
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
   const { tasks, lists, order, moveTask, reorderTask } = useStore();
 
   const today = new Date().toISOString().slice(0, 10);
 
-  const columns = mode === 'my-day'
-    ? [
-        { id: 'todo', title: 'To Do' },
-        { id: 'doing', title: 'In Progress' },
-        { id: 'done', title: 'Done' },
-      ]
-    : [...lists].sort((a, b) => a.order - b.order).map((l) => ({ id: l.id, title: l.title }));
+  const columns =
+    mode === 'my-day'
+      ? [
+          { id: 'todo', title: 'To Do' },
+          { id: 'doing', title: 'In Progress' },
+          { id: 'done', title: 'Done' },
+        ]
+      : [...lists]
+          .sort((a, b) => a.order - b.order)
+          .map(l => ({ id: l.id, title: l.title }));
 
   function getTasks(columnId: string): Task[] {
     const key = mode === 'my-day' ? `day-${columnId}` : `list-${columnId}`;
     const ids = order[key] || [];
     return ids
-      .map((id) => tasks.find((t) => t.id === id))
+      .map(id => tasks.find(t => t.id === id))
       .filter((t): t is Task => !!t)
-      .filter((t) => (mode === 'my-day' ? t.plannedFor === today : true));
+      .filter(t => (mode === 'my-day' ? t.plannedFor === today : true));
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -36,8 +48,11 @@ export default function Board({ mode }: BoardProps) {
     if (!over) return;
     const activeId = active.id as string;
     const activeContainer = active.data.current?.sortable.containerId as string;
-    const overContainer = over.data.current?.sortable.containerId as string;
-    const overIndex = over.data.current?.sortable.index as number;
+    const overContainer =
+      (over.data.current?.sortable?.containerId as string) ||
+      (over.id as string);
+    const overIndex =
+      over.data.current?.sortable?.index ?? getTasks(overContainer).length;
 
     if (activeContainer === overContainer) {
       reorderTask(activeId, overContainer, overIndex, mode);
@@ -52,10 +67,19 @@ export default function Board({ mode }: BoardProps) {
   };
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragEnd={handleDragEnd}
+    >
       <div className="flex gap-4 overflow-x-auto p-4">
-        {columns.map((col) => (
-          <Column key={col.id} id={col.id} title={col.title} tasks={getTasks(col.id)} />
+        {columns.map(col => (
+          <Column
+            key={col.id}
+            id={col.id}
+            title={col.title}
+            tasks={getTasks(col.id)}
+          />
         ))}
       </div>
     </DndContext>

--- a/components/Column.tsx
+++ b/components/Column.tsx
@@ -1,5 +1,9 @@
 'use client';
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { useDroppable } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { Task } from '../lib/types';
 import TaskCard from './TaskCard';
 
@@ -10,13 +14,25 @@ interface ColumnProps {
 }
 
 export default function Column({ id, title, tasks }: ColumnProps) {
+  const { setNodeRef } = useDroppable({ id });
+
   return (
-    <div className="w-80 flex-shrink-0">
+    <div
+      ref={setNodeRef}
+      className="w-80 flex-shrink-0"
+    >
       <h2 className="mb-2 text-lg font-semibold">{title}</h2>
-      <SortableContext id={id} items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="space-y-2">
-          {tasks.map((task) => (
-            <TaskCard key={task.id} task={task} />
+      <SortableContext
+        id={id}
+        items={tasks.map(t => t.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-2 min-h-4">
+          {tasks.map(task => (
+            <TaskCard
+              key={task.id}
+              task={task}
+            />
           ))}
         </div>
       </SortableContext>

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -7,6 +7,7 @@ import { useStore } from '../lib/store';
 
 interface Props {
   task: Task;
+  dragOverlay?: boolean;
 }
 
 const priorityColors = {
@@ -15,12 +16,18 @@ const priorityColors = {
   high: 'border-l-red-500',
 };
 
-export default function TaskCard({ task }: Props) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: task.id });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
+export default function TaskCard({ task, dragOverlay = false }: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: task.id,
+      disabled: dragOverlay,
+    });
+  const style = dragOverlay
+    ? undefined
+    : {
+        transform: CSS.Transform.toString(transform),
+        transition,
+      };
   const { moveTask, tags: allTags } = useStore();
   const markDone = () => {
     if (task.dayStatus !== 'done') {
@@ -45,18 +52,29 @@ export default function TaskCard({ task }: Props) {
         <span>{task.title}</span>
         <div className="flex items-center gap-2">
           {task.dayStatus !== 'done' && (
-            <button onClick={markDone} aria-label="Mark as done" className="text-green-400 hover:text-green-500">
+            <button
+              onClick={markDone}
+              aria-label="Mark as done"
+              className="text-green-400 hover:text-green-500"
+            >
               <Check className="h-4 w-4" />
             </button>
           )}
-          <button aria-label="Edit task" className="text-gray-400 hover:text-gray-200">
+          <button
+            aria-label="Edit task"
+            className="text-gray-400 hover:text-gray-200"
+          >
             <Edit className="h-4 w-4" />
           </button>
         </div>
       </div>
       <div className="mt-2 flex flex-wrap gap-1">
         {task.tags?.map(tag => (
-          <span key={tag} style={{ backgroundColor: getTagColor(tag) }} className="text-xs px-2 py-1 rounded-full">
+          <span
+            key={tag}
+            style={{ backgroundColor: getTagColor(tag) }}
+            className="text-xs px-2 py-1 rounded-full"
+          >
             {tag}
           </span>
         ))}


### PR DESCRIPTION
## Summary
- make My Day board columns droppable
- update drag handler to move tasks across day columns

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prettier formatting errors across repository)*
- `npm run build` *(fails: prettier formatting errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b2f5494832cb9e97515f3596979