### PR TITLE
style: enhance My Day view spacing

### DIFF
--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -105,6 +105,7 @@ export default function Board({ mode }: BoardProps) {
             id={col.id}
             title={col.title}
             tasks={getTasks(col.id)}
+            mode={mode}
           />
         ))}
       </div>

--- a/components/Column.tsx
+++ b/components/Column.tsx
@@ -11,15 +11,20 @@ interface ColumnProps {
   id: string;
   title: string;
   tasks: Task[];
+  mode: 'my-day' | 'kanban';
 }
 
-export default function Column({ id, title, tasks }: ColumnProps) {
+export default function Column({ id, title, tasks, mode }: ColumnProps) {
   const { setNodeRef } = useDroppable({ id });
+  const containerClasses =
+    mode === 'my-day' ? 'flex-1 min-w-0' : 'w-80 flex-shrink-0';
+  const listClasses =
+    mode === 'my-day' ? 'space-y-4 min-h-4' : 'space-y-2 min-h-4';
 
   return (
     <div
       ref={setNodeRef}
-      className="w-80 flex-shrink-0"
+      className={containerClasses}
     >
       <h2 className="mb-2 text-lg font-semibold">{title}</h2>
       <SortableContext
@@ -27,7 +32,7 @@ export default function Column({ id, title, tasks }: ColumnProps) {
         items={tasks.map(t => t.id)}
         strategy={verticalListSortingStrategy}
       >
-        <div className="space-y-2 min-h-4">
+        <div className={listClasses}>
           {tasks.map(task => (
             <TaskCard
               key={task.id}

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -46,7 +46,7 @@ export default function TaskCard({ task, dragOverlay = false }: Props) {
       style={style}
       {...attributes}
       {...listeners}
-      className={`rounded border-l-4 p-2 cursor-grab focus:outline-none focus:ring bg-gray-100 dark:bg-gray-800 ${priorityColors[task.priority]}`}
+      className={`rounded border-l-4 p-4 cursor-grab focus:outline-none focus:ring bg-gray-100 dark:bg-gray-800 ${priorityColors[task.priority]}`}
     >
       <div className="flex items-center justify-between">
         <span>{task.title}</span>


### PR DESCRIPTION
## Summary
- expand task card padding for clearer spacing
- make My Day columns flex to fill the viewport with wider task spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c2b7eb1b0832ca730ff778c26929a