### PR TITLE
feat: add multilingual support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,16 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import Header from '../components/Header';
+import { I18nProvider } from '../lib/i18n';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-        <Header />
-        {children}
+        <I18nProvider>
+          <Header />
+          {children}
+        </I18nProvider>
       </body>
     </html>
   );

--- a/components/AddTask.tsx
+++ b/components/AddTask.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Priority, Tag } from '../lib/types';
+import { useI18n } from '../lib/i18n';
 
 export default function AddTask({
   addTask,
@@ -19,6 +20,7 @@ export default function AddTask({
   const [title, setTitle] = useState('');
   const [tags, setTags] = useState<string[]>([]);
   const [priority, setPriority] = useState<Priority>('medium');
+  const { t } = useI18n();
 
   const handleAdd = () => {
     if (!title.trim()) return;
@@ -55,27 +57,27 @@ export default function AddTask({
         htmlFor="task-title"
         className="sr-only"
       >
-        Title
+        {t('addTask.titleLabel')}
       </label>
       <input
         id="task-title"
         value={title}
         onChange={e => setTitle(e.target.value)}
         className="flex-1 rounded bg-gray-200 p-2 text-sm focus:ring dark:bg-gray-800"
-        placeholder="New task"
+        placeholder={t('addTask.titlePlaceholder')}
       />
       <div className="flex items-center gap-2">
         <label
           htmlFor="task-tags"
           className="sr-only"
         >
-          Tags
+          {t('addTask.tagsLabel')}
         </label>
         <input
           id="task-tags"
           onKeyDown={handleTagInputChange}
           className="rounded bg-gray-200 p-2 text-sm focus:ring dark:bg-gray-800"
-          placeholder="Add tags (press Enter)"
+          placeholder={t('addTask.tagsPlaceholder')}
           list="existing-tags"
         />
         <datalist id="existing-tags">
@@ -107,7 +109,7 @@ export default function AddTask({
         htmlFor="task-priority"
         className="sr-only"
       >
-        Priority
+        {t('addTask.priorityLabel')}
       </label>
       <select
         id="task-priority"
@@ -115,15 +117,15 @@ export default function AddTask({
         onChange={e => setPriority(e.target.value as Priority)}
         className="rounded bg-gray-200 p-2 text-sm focus:ring dark:bg-gray-800"
       >
-        <option value="low">Low</option>
-        <option value="medium">Medium</option>
-        <option value="high">High</option>
+        <option value="low">{t('priority.low')}</option>
+        <option value="medium">{t('priority.medium')}</option>
+        <option value="high">{t('priority.high')}</option>
       </select>
       <button
         type="submit"
         className="flex items-center gap-1 rounded bg-blue-600 px-3 py-2 text-sm hover:bg-blue-700 focus:ring"
       >
-        <Plus className="h-4 w-4" /> Add
+        <Plus className="h-4 w-4" /> {t('addTask.addButton')}
       </button>
     </form>
   );

--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -15,6 +15,7 @@ import { Task } from '../lib/types';
 import { useStore } from '../lib/store';
 import Column from './Column';
 import TaskCard from './TaskCard';
+import { useI18n } from '../lib/i18n';
 
 interface BoardProps {
   mode: 'my-day' | 'kanban';
@@ -26,19 +27,26 @@ export default function Board({ mode }: BoardProps) {
   );
   const { tasks, lists, order, moveTask, reorderTask } = useStore();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const { t } = useI18n();
 
   const today = new Date().toISOString().slice(0, 10);
 
   const columns =
     mode === 'my-day'
       ? [
-          { id: 'todo', title: 'To Do' },
-          { id: 'doing', title: 'In Progress' },
-          { id: 'done', title: 'Done' },
+          { id: 'todo', title: t('board.todo') },
+          { id: 'doing', title: t('board.doing') },
+          { id: 'done', title: t('board.done') },
         ]
       : [...lists]
           .sort((a, b) => a.order - b.order)
-          .map(l => ({ id: l.id, title: l.title }));
+          .map(l => {
+            const title = t(`lists.${l.id}`);
+            return {
+              id: l.id,
+              title: title.startsWith('lists.') ? l.title : title,
+            };
+          });
 
   function getTasks(columnId: string): Task[] {
     const key = mode === 'my-day' ? `day-${columnId}` : `list-${columnId}`;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,10 +3,13 @@ import Link from 'next/link';
 import { Download, Upload, Trash2, Sun, Moon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useStore } from '../lib/store';
+import { useI18n, Language } from '../lib/i18n';
 
 export default function Header() {
   const { exportData, importData, clearAll } = useStore();
   const [showConfirm, setShowConfirm] = useState(false);
+  const { t, language, setLanguage } = useI18n();
+  const [showLang, setShowLang] = useState(false);
 
   const handleDelete = () => {
     clearAll();
@@ -54,25 +57,25 @@ export default function Header() {
             href="/my-day"
             className="hover:underline focus:underline"
           >
-            My Day
+            {t('nav.myDay')}
           </Link>
           <Link
             href="/my-tasks"
             className="hover:underline focus:underline"
           >
-            My Tasks
+            {t('nav.myTasks')}
           </Link>
         </nav>
         <div className="flex items-center gap-2">
           <button
             onClick={exportData}
-            aria-label="Export"
+            aria-label={t('actions.export')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             <Download className="h-4 w-4" />
           </button>
           <label
-            aria-label="Import"
+            aria-label={t('actions.import')}
             className="cursor-pointer rounded p-2 hover:bg-gray-200 focus-within:bg-gray-200 dark:hover:bg-gray-800 dark:focus-within:bg-gray-800"
           >
             <Upload className="h-4 w-4" />
@@ -85,14 +88,14 @@ export default function Header() {
           </label>
           <button
             onClick={() => setShowConfirm(true)}
-            aria-label="Clear all"
+            aria-label={t('actions.clearAll')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             <Trash2 className="h-4 w-4" />
           </button>
           <button
             onClick={toggleTheme}
-            aria-label="Toggle theme"
+            aria-label={t('actions.toggleTheme')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             {theme === 'dark' ? (
@@ -101,28 +104,49 @@ export default function Header() {
               <Moon className="h-4 w-4" />
             )}
           </button>
+          <div className="relative">
+            <button
+              onClick={() => setShowLang(v => !v)}
+              aria-label={t('actions.language')}
+              className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+            >
+              {language.toUpperCase()}
+            </button>
+            {showLang && (
+              <div className="absolute right-0 mt-2 rounded bg-gray-100 shadow dark:bg-gray-800">
+                {(['en', 'es'] as Language[]).map(code => (
+                  <button
+                    key={code}
+                    onClick={() => {
+                      setLanguage(code);
+                      setShowLang(false);
+                    }}
+                    className="block w-full px-4 py-2 text-left hover:bg-gray-200 dark:hover:bg-gray-700"
+                  >
+                    {code.toUpperCase()} - {t(`lang.${code}`)}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </header>
       {showConfirm && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">
-            <p className="mb-4">
-              Are you sure you want to delete the dashboard? We recommend
-              exporting it so you can restore your work later by importing the
-              dashboard.
-            </p>
+            <p className="mb-4">{t('confirmDelete.message')}</p>
             <div className="flex justify-center gap-2">
               <button
                 onClick={() => setShowConfirm(false)}
                 className="rounded bg-gray-700 px-3 py-1 hover:bg-gray-600 focus:bg-gray-600"
               >
-                Cancel
+                {t('confirmDelete.cancel')}
               </button>
               <button
                 onClick={handleDelete}
                 className="rounded bg-red-600 px-3 py-1 hover:bg-red-500 focus:bg-red-500"
               >
-                Delete
+                {t('confirmDelete.delete')}
               </button>
             </div>
           </div>

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -4,6 +4,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Check } from 'lucide-react';
 import { Task } from '../lib/types';
 import { useStore } from '../lib/store';
+import { useI18n } from '../lib/i18n';
 
 interface Props {
   task: Task;
@@ -29,6 +30,7 @@ export default function TaskCard({ task, dragOverlay = false }: Props) {
         transition,
       };
   const { moveTask, tags: allTags } = useStore();
+  const { t } = useI18n();
   const markDone = () => {
     if (task.dayStatus !== 'done') {
       moveTask(task.id, { dayStatus: 'done' });
@@ -54,7 +56,7 @@ export default function TaskCard({ task, dragOverlay = false }: Props) {
           {task.dayStatus !== 'done' && (
             <button
               onClick={markDone}
-              aria-label="Mark as done"
+              aria-label={t('taskCard.markDone')}
               className="text-green-400 hover:text-green-500"
             >
               <Check className="h-4 w-4" />

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { CalendarPlus, CalendarX, Trash2 } from 'lucide-react';
 import { useStore } from '../lib/store';
 import { Priority } from '../lib/types';
+import { useI18n } from '../lib/i18n';
 
 interface Props {
   taskId: string;
@@ -20,6 +21,7 @@ export default function TaskItem({ taskId }: Props) {
   const task = tasks.find(t => t.id === taskId);
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(task?.title ?? '');
+  const { t } = useI18n();
 
   if (!task) {
     return null;
@@ -105,13 +107,15 @@ export default function TaskItem({ taskId }: Props) {
           }
           className="rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
         >
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
+          <option value="low">{t('priority.low')}</option>
+          <option value="medium">{t('priority.medium')}</option>
+          <option value="high">{t('priority.high')}</option>
         </select>
         <button
           onClick={() => toggleMyDay(task.id)}
-          aria-label={task.plannedFor ? 'Remove from My Day' : 'Add to My Day'}
+          aria-label={
+            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
+          }
           className="rounded bg-blue-600 p-1 text-white hover:bg-blue-700 focus:ring"
         >
           {task.plannedFor ? (
@@ -122,7 +126,7 @@ export default function TaskItem({ taskId }: Props) {
         </button>
         <button
           onClick={() => removeTask(task.id)}
-          aria-label="Delete task"
+          aria-label={t('taskItem.deleteTask')}
           className="rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:ring"
         >
           <Trash2 className="h-4 w-4" />
@@ -149,7 +153,7 @@ export default function TaskItem({ taskId }: Props) {
         <input
           onKeyDown={handleTagInputChange}
           className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
-          placeholder="Add tag"
+          placeholder={t('taskItem.tagPlaceholder')}
           list="existing-tags"
         />
         <datalist id="existing-tags">

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -1,11 +1,13 @@
 'use client';
 import TaskItem from './TaskItem';
 import { Task } from '../lib/types';
+import { useI18n } from '../lib/i18n';
 
 export default function TaskList({ tasks }: { tasks: Task[] }) {
   const sorted = [...tasks].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   );
+  const { t } = useI18n();
   return (
     <div className="space-y-2 p-4">
       {sorted.map(task => (
@@ -16,7 +18,7 @@ export default function TaskList({ tasks }: { tasks: Task[] }) {
       ))}
       {sorted.length === 0 && (
         <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-          No tasks
+          {t('taskList.noTasks')}
         </p>
       )}
     </div>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,149 @@
+'use client';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react';
+
+export type Language = 'en' | 'es';
+
+const translations: Record<Language, any> = {
+  en: {
+    nav: { myDay: 'My Day', myTasks: 'My Tasks' },
+    actions: {
+      export: 'Export',
+      import: 'Import',
+      clearAll: 'Clear all',
+      toggleTheme: 'Toggle theme',
+      language: 'Select language',
+    },
+    confirmDelete: {
+      message:
+        'Are you sure you want to delete the dashboard? We recommend exporting it so you can restore your work later by importing the dashboard.',
+      cancel: 'Cancel',
+      delete: 'Delete',
+    },
+    board: { todo: 'To Do', doing: 'In Progress', done: 'Done' },
+    lists: {
+      ideas: 'Ideas',
+      backlog: 'Backlog',
+      inprogress: 'In Progress',
+      done: 'Done',
+    },
+    addTask: {
+      titleLabel: 'Title',
+      titlePlaceholder: 'New task',
+      tagsLabel: 'Tags',
+      tagsPlaceholder: 'Add tags (press Enter)',
+      priorityLabel: 'Priority',
+      addButton: 'Add',
+    },
+    taskCard: { markDone: 'Mark as done' },
+    taskItem: {
+      removeMyDay: 'Remove from My Day',
+      addMyDay: 'Add to My Day',
+      deleteTask: 'Delete task',
+      tagPlaceholder: 'Add tag',
+    },
+    priority: { low: 'Low', medium: 'Medium', high: 'High' },
+    taskList: { noTasks: 'No tasks' },
+    lang: { en: 'English', es: 'Spanish' },
+  },
+  es: {
+    nav: { myDay: 'Mi Día', myTasks: 'Mis Tareas' },
+    actions: {
+      export: 'Exportar',
+      import: 'Importar',
+      clearAll: 'Eliminar todo',
+      toggleTheme: 'Cambiar tema',
+      language: 'Seleccionar idioma',
+    },
+    confirmDelete: {
+      message:
+        '¿Seguro que quieres borrar el panel? Recomendamos exportarlo para que puedas restaurar tu trabajo más tarde importando el panel.',
+      cancel: 'Cancelar',
+      delete: 'Eliminar',
+    },
+    board: { todo: 'Por hacer', doing: 'En progreso', done: 'Hecho' },
+    lists: {
+      ideas: 'Ideas',
+      backlog: 'Pendientes',
+      inprogress: 'En Progreso',
+      done: 'Hecho',
+    },
+    addTask: {
+      titleLabel: 'Título',
+      titlePlaceholder: 'Nueva tarea',
+      tagsLabel: 'Etiquetas',
+      tagsPlaceholder: 'Añade etiquetas (presiona Enter)',
+      priorityLabel: 'Prioridad',
+      addButton: 'Añadir',
+    },
+    taskCard: { markDone: 'Marcar como completada' },
+    taskItem: {
+      removeMyDay: 'Quitar de Mi Día',
+      addMyDay: 'Agregar a Mi Día',
+      deleteTask: 'Eliminar tarea',
+      tagPlaceholder: 'Añadir etiqueta',
+    },
+    priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
+    taskList: { noTasks: 'No hay tareas' },
+    lang: { en: 'Inglés', es: 'Español' },
+  },
+};
+
+interface I18nContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextType>({
+  language: 'en',
+  setLanguage: () => {},
+  t: key => key,
+});
+
+function getTranslation(lang: Language, key: string): string {
+  const parts = key.split('.');
+  let result: any = translations[lang];
+  for (const part of parts) {
+    if (result && typeof result === 'object') {
+      result = result[part];
+    } else {
+      result = undefined;
+      break;
+    }
+  }
+  return typeof result === 'string' ? result : key;
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Language>('en');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lang');
+    if (stored === 'en' || stored === 'es') {
+      setLanguage(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+    localStorage.setItem('lang', language);
+  }, [language]);
+
+  const t = (key: string) => getTranslation(language, key);
+
+  return (
+    <I18nContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}


### PR DESCRIPTION
## Summary
- add i18n provider with English and Spanish translations
- allow switching language from header and persist preference
- replace hard-coded UI strings with translated versions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c2d2c59b8832c938613793b15be1a