### PR TITLE
Add delete option for completed My Day tasks

### DIFF
--- a/components/Column/Column.tsx
+++ b/components/Column/Column.tsx
@@ -33,6 +33,7 @@ export default function Column({ id, title, tasks, mode }: ColumnProps) {
             <TaskCard
               key={task.id}
               task={task}
+              mode={mode}
             />
           ))}
         </div>

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Check } from 'lucide-react';
+import { Check, Trash2 } from 'lucide-react';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
 
 const priorityColors = {
@@ -11,8 +11,8 @@ const priorityColors = {
 export default function TaskCard(props: UseTaskCardProps) {
   const { state, actions } = useTaskCard(props);
   const { attributes, listeners, setNodeRef, style, t } = state;
-  const { markDone, getTagColor } = actions;
-  const { task } = props;
+  const { markDone, getTagColor, deleteTask } = actions;
+  const { task, mode } = props;
 
   return (
     <div
@@ -32,6 +32,15 @@ export default function TaskCard(props: UseTaskCardProps) {
               className="text-green-400 hover:text-green-500"
             >
               <Check className="h-4 w-4" />
+            </button>
+          )}
+          {mode === 'my-day' && task.dayStatus === 'done' && (
+            <button
+              onClick={deleteTask}
+              aria-label={t('taskCard.deleteTask')}
+              className="text-red-400 hover:text-red-500"
+            >
+              <Trash2 className="h-4 w-4" />
             </button>
           )}
         </div>

--- a/components/TaskCard/useTaskCard.ts
+++ b/components/TaskCard/useTaskCard.ts
@@ -8,6 +8,7 @@ import { useI18n } from '../../lib/i18n';
 export interface UseTaskCardProps {
   task: Task;
   dragOverlay?: boolean;
+  mode?: 'my-day' | 'kanban';
 }
 
 export default function useTaskCard({
@@ -25,13 +26,17 @@ export default function useTaskCard({
         transform: CSS.Transform.toString(transform),
         transition,
       };
-  const { moveTask, tags: allTags } = useStore();
+  const { moveTask, removeTask, tags: allTags } = useStore();
   const { t } = useI18n();
 
   const markDone = () => {
     if (task.dayStatus !== 'done') {
       moveTask(task.id, { dayStatus: 'done' });
     }
+  };
+
+  const deleteTask = () => {
+    removeTask(task.id);
   };
 
   const getTagColor = (tagLabel: string) => {
@@ -41,6 +46,6 @@ export default function useTaskCard({
 
   return {
     state: { attributes, listeners, setNodeRef, style, t, allTags },
-    actions: { markDone, getTagColor },
+    actions: { markDone, getTagColor, deleteTask },
   } as const;
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -40,7 +40,10 @@ const translations: Record<Language, any> = {
       priorityLabel: 'Priority',
       addButton: 'Add',
     },
-    taskCard: { markDone: 'Mark as done' },
+    taskCard: {
+      markDone: 'Mark as done',
+      deleteTask: 'Delete task',
+    },
     taskItem: {
       removeMyDay: 'Remove from My Day',
       addMyDay: 'Add to My Day',
@@ -81,7 +84,10 @@ const translations: Record<Language, any> = {
       priorityLabel: 'Prioridad',
       addButton: 'Añadir',
     },
-    taskCard: { markDone: 'Marcar como completada' },
+    taskCard: {
+      markDone: 'Marcar como completada',
+      deleteTask: 'Eliminar tarea',
+    },
     taskItem: {
       removeMyDay: 'Quitar de Mi Día',
       addMyDay: 'Agregar a Mi Día',


### PR DESCRIPTION
## Summary
- show remove button for tasks completed in My Day
- pass board mode to task cards and wire delete action
- localize delete task label

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d6e677d94832c970291b918b2f531