### PR TITLE
Order My Tasks by priority

### DIFF
--- a/components/TaskList/useTaskList.ts
+++ b/components/TaskList/useTaskList.ts
@@ -7,14 +7,19 @@ export interface UseTaskListProps {
 }
 
 export default function useTaskList({ tasks }: UseTaskListProps) {
-  const sorted = useMemo(
-    () =>
-      [...tasks].sort(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      ),
-    [tasks]
-  );
+  const sorted = useMemo(() => {
+    const priorityOrder: Record<Task['priority'], number> = {
+      low: 0,
+      medium: 1,
+      high: 2,
+    };
+    return [...tasks].sort((a, b) => {
+      const priorityDiff =
+        priorityOrder[b.priority] - priorityOrder[a.priority];
+      if (priorityDiff !== 0) return priorityDiff;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+  }, [tasks]);
 
   return {
     state: { sorted },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -85,7 +85,22 @@ export const useStore = create<Store>((set, get) => ({
     set(state => {
       const newOrder = { ...state.order };
       const listKey = `list-backlog`;
-      newOrder[listKey] = [...(newOrder[listKey] || []), id];
+      const ids = newOrder[listKey] || [];
+      const priorityOrder: Record<Priority, number> = {
+        low: 0,
+        medium: 1,
+        high: 2,
+      };
+      let insertIndex = ids.findIndex(tid => {
+        const t = state.tasks.find(task => task.id === tid);
+        return t && priorityOrder[t.priority] < priorityOrder[priority];
+      });
+      if (insertIndex === -1) insertIndex = ids.length;
+      newOrder[listKey] = [
+        ...ids.slice(0, insertIndex),
+        id,
+        ...ids.slice(insertIndex),
+      ];
       return { tasks: [...state.tasks, task], order: newOrder };
     });
     saveState(get());


### PR DESCRIPTION
## Summary
- sort My Tasks by priority with high priority first and keep creation order within the same priority
- insert new backlog tasks into priority-based positions so board ordering matches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d6f3a33fc832c84c51148ceb651f2