### PR TITLE
feat: display My Day task count in header

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import useHeader from './useHeader';
 
 export default function Header() {
   const { state, actions } = useHeader();
-  const { showConfirm, showLang, theme, t, language } = state;
+  const { showConfirm, showLang, theme, t, language, myDayCount } = state;
   const {
     exportData,
     setShowConfirm,
@@ -23,9 +23,12 @@ export default function Header() {
         <nav className="flex gap-4">
           <Link
             href="/my-day"
-            className="hover:underline focus:underline"
+            className="flex items-center hover:underline focus:underline"
           >
             {t('nav.myDay')}
+            <span className="ml-1 rounded-full bg-blue-600 px-2 py-0.5 text-xs text-white">
+              {myDayCount}
+            </span>
           </Link>
           <Link
             href="/my-tasks"

--- a/components/Header/useHeader.ts
+++ b/components/Header/useHeader.ts
@@ -4,11 +4,18 @@ import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
 
 export default function useHeader() {
-  const { exportData, importData, clearAll } = useStore();
+  const { tasks, exportData, importData, clearAll } = useStore(state => ({
+    tasks: state.tasks,
+    exportData: state.exportData,
+    importData: state.importData,
+    clearAll: state.clearAll,
+  }));
   const { t, language, setLanguage } = useI18n();
   const [showConfirm, setShowConfirm] = useState(false);
   const [showLang, setShowLang] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+  const today = new Date().toISOString().slice(0, 10);
+  const myDayCount = tasks.filter(t => t.plannedFor === today).length;
 
   useEffect(() => {
     const stored = localStorage.getItem('theme');
@@ -48,7 +55,7 @@ export default function useHeader() {
   };
 
   return {
-    state: { showConfirm, showLang, theme, t, language },
+    state: { showConfirm, showLang, theme, t, language, myDayCount },
     actions: {
       exportData,
       setShowConfirm,


### PR DESCRIPTION
## Summary
- show number of today's My Day tasks next to My Day link in header
- compute count from store and expose via useHeader

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d7758fef4832c93fb0cc2eeefa586