### PR TITLE
Add titles to icon-only buttons

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -63,6 +63,8 @@ export default function AddTask(props: UseAddTaskProps) {
               {tag}
               <button
                 onClick={() => removeTag(tag)}
+                aria-label={t('actions.removeTag')}
+                title={t('actions.removeTag')}
                 className="ml-1 text-red-500"
               >
                 x

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -38,12 +38,14 @@ export default function Header() {
           <button
             onClick={exportData}
             aria-label={t('actions.export')}
+            title={t('actions.export')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             <Download className="h-4 w-4" />
           </button>
           <label
             aria-label={t('actions.import')}
+            title={t('actions.import')}
             className="cursor-pointer rounded p-2 hover:bg-gray-200 focus-within:bg-gray-200 dark:hover:bg-gray-800 dark:focus-within:bg-gray-800"
           >
             <Upload className="h-4 w-4" />
@@ -57,6 +59,7 @@ export default function Header() {
           <button
             onClick={() => setShowConfirm(true)}
             aria-label={t('actions.clearAll')}
+            title={t('actions.clearAll')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             <Trash2 className="h-4 w-4" />
@@ -64,6 +67,7 @@ export default function Header() {
           <button
             onClick={toggleTheme}
             aria-label={t('actions.toggleTheme')}
+            title={t('actions.toggleTheme')}
             className="rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
           >
             {theme === 'dark' ? (

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -35,6 +35,7 @@ export default function TaskCard(props: UseTaskCardProps) {
             <button
               onClick={markDone}
               aria-label={t('taskCard.markDone')}
+              title={t('taskCard.markDone')}
               className="text-green-400 hover:text-green-500"
             >
               <Check className="h-4 w-4" />
@@ -44,6 +45,7 @@ export default function TaskCard(props: UseTaskCardProps) {
             <button
               onClick={deleteTask}
               aria-label={t('taskCard.deleteTask')}
+              title={t('taskCard.deleteTask')}
               className="text-red-400 hover:text-red-500"
             >
               <Trash2 className="h-4 w-4" />

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -69,6 +69,9 @@ export default function TaskItem({ taskId }: UseTaskItemProps) {
           aria-label={
             task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
           }
+          title={
+            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
+          }
           className={`rounded p-1 focus:ring ${
             task.plannedFor
               ? 'bg-yellow-500 text-black hover:bg-yellow-600'
@@ -84,6 +87,7 @@ export default function TaskItem({ taskId }: UseTaskItemProps) {
         <button
           onClick={() => removeTask(task.id)}
           aria-label={t('taskItem.deleteTask')}
+          title={t('taskItem.deleteTask')}
           className="rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:ring"
         >
           <Trash2 className="h-4 w-4" />
@@ -100,6 +104,8 @@ export default function TaskItem({ taskId }: UseTaskItemProps) {
               {tag}
               <button
                 onClick={() => removeTag(tag)}
+                aria-label={t('actions.removeTag')}
+                title={t('actions.removeTag')}
                 className="ml-1 text-red-500"
               >
                 x

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -18,6 +18,7 @@ const translations: Record<Language, any> = {
       clearAll: 'Clear all',
       toggleTheme: 'Toggle theme',
       language: 'Select language',
+      removeTag: 'Remove tag',
     },
     confirmDelete: {
       message:
@@ -62,6 +63,7 @@ const translations: Record<Language, any> = {
       clearAll: 'Eliminar todo',
       toggleTheme: 'Cambiar tema',
       language: 'Seleccionar idioma',
+      removeTag: 'Eliminar etiqueta',
     },
     confirmDelete: {
       message:


### PR DESCRIPTION
## Summary
- add `title` attributes to header, task, and tag action buttons
- localize new `Remove tag` title string

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d78d81ce8832cb08270e1d217e13e