### PR TITLE
feat: add tag filter to tasks view

### DIFF
--- a/components/TagFilter/TagFilter.tsx
+++ b/components/TagFilter/TagFilter.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { Tag } from '../../lib/types';
+import { useI18n } from '../../lib/i18n';
+
+interface TagFilterProps {
+  tags: Tag[];
+  activeTags: string[];
+  toggleTag: (label: string) => void;
+  showAll: () => void;
+}
+
+export default function TagFilter({
+  tags,
+  activeTags,
+  toggleTag,
+  showAll,
+}: TagFilterProps) {
+  const { t } = useI18n();
+  if (tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-4 pb-2">
+      {tags.map(tag => {
+        const isActive = activeTags.includes(tag.label);
+        return (
+          <button
+            key={tag.id}
+            onClick={() => toggleTag(tag.label)}
+            style={{ backgroundColor: isActive ? tag.color : '#ccc' }}
+            className="rounded-full px-2 py-1 text-xs"
+          >
+            {tag.label}
+          </button>
+        );
+      })}
+      <button
+        onClick={showAll}
+        className="text-xs underline"
+      >
+        {t('tagFilter.showAll')}
+      </button>
+    </div>
+  );
+}

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -1,18 +1,25 @@
 'use client';
 import AddTask from '../AddTask/AddTask';
 import TaskList from '../TaskList/TaskList';
+import TagFilter from '../TagFilter/TagFilter';
 import useTasksView from './useTasksView';
 
 export default function TasksView() {
   const { state, actions } = useTasksView();
-  const { tasks, tags } = state;
-  const { addTask, addTag } = actions;
+  const { tasks, tags, activeTags } = state;
+  const { addTask, addTag, toggleTagFilter, resetTagFilter } = actions;
   return (
     <main>
       <AddTask
         addTask={addTask}
         tags={tags}
         addTag={addTag}
+      />
+      <TagFilter
+        tags={tags}
+        activeTags={activeTags}
+        toggleTag={toggleTagFilter}
+        showAll={resetTagFilter}
       />
       <TaskList tasks={tasks} />
     </main>

--- a/components/TasksView/useTasksView.ts
+++ b/components/TasksView/useTasksView.ts
@@ -1,10 +1,43 @@
 'use client';
+import { useEffect, useMemo, useState } from 'react';
 import { useStore } from '../../lib/store';
 
 export default function useTasksView() {
   const store = useStore();
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    setActiveTags(prev => {
+      const labels = store.tags.map(t => t.label);
+      const newTags = labels.filter(l => !prev.includes(l));
+      return [...prev, ...newTags];
+    });
+  }, [store.tags]);
+
+  const toggleTagFilter = (label: string) => {
+    setActiveTags(prev =>
+      prev.includes(label) ? prev.filter(t => t !== label) : [...prev, label]
+    );
+  };
+
+  const resetTagFilter = () => {
+    setActiveTags(store.tags.map(t => t.label));
+  };
+
+  const filteredTasks = useMemo(() => {
+    return store.tasks.filter(task => {
+      if (task.tags.length === 0) return true;
+      return task.tags.some(tag => activeTags.includes(tag));
+    });
+  }, [store.tasks, activeTags]);
+
   return {
-    state: { tasks: store.tasks, tags: store.tags },
-    actions: { addTask: store.addTask, addTag: store.addTag },
+    state: { tasks: filteredTasks, tags: store.tags, activeTags },
+    actions: {
+      addTask: store.addTask,
+      addTag: store.addTag,
+      toggleTagFilter,
+      resetTagFilter,
+    },
   } as const;
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -52,6 +52,7 @@ const translations: Record<Language, any> = {
     },
     priority: { low: 'Low', medium: 'Medium', high: 'High' },
     taskList: { noTasks: 'No tasks' },
+    tagFilter: { showAll: 'Show all tasks' },
     lang: { en: 'English', es: 'Spanish' },
   },
   es: {
@@ -96,6 +97,7 @@ const translations: Record<Language, any> = {
     },
     priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
     taskList: { noTasks: 'No hay tareas' },
+    tagFilter: { showAll: 'Mostrar todas las tareas' },
     lang: { en: 'Inglés', es: 'Español' },
   },
 };


### PR DESCRIPTION
## Summary
- add tag filter component to toggle tags in My Tasks view
- filter tasks client-side using selected tags
- include translations for new filter actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d7d53318c832c8be7b2d01dde5c8e