### PR TITLE
Add footer with navigation links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,15 +2,17 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import Header from '../components/Header/Header';
+import Footer from '../components/Footer/Footer';
 import { I18nProvider } from '../lib/i18n';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <body className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
         <I18nProvider>
           <Header />
-          {children}
+          <main className="flex-1">{children}</main>
+          <Footer />
         </I18nProvider>
       </body>
     </html>

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { useI18n } from '../../lib/i18n';
+
+export default function Footer() {
+  const { t } = useI18n();
+
+  return (
+    <footer className="bg-gray-100 py-4 dark:bg-gray-950">
+      <nav className="mx-auto flex flex-wrap justify-center gap-4 px-4 text-sm text-gray-600 dark:text-gray-400">
+        <Link
+          href="/about"
+          className="hover:underline"
+        >
+          {t('footer.about')}
+        </Link>
+        <Link
+          href="https://github.com/AntonioHCervantes/local-quick-planner"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          {t('footer.openSource')}
+        </Link>
+        <Link
+          href="/faqs"
+          className="hover:underline"
+        >
+          {t('footer.faqs')}
+        </Link>
+        <Link
+          href="/privacy"
+          className="hover:underline"
+        >
+          {t('footer.privacy')}
+        </Link>
+        <Link
+          href="/terms"
+          className="hover:underline"
+        >
+          {t('footer.terms')}
+        </Link>
+      </nav>
+    </footer>
+  );
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -54,6 +54,13 @@ const translations: Record<Language, any> = {
     priority: { low: 'Low', medium: 'Medium', high: 'High' },
     taskList: { noTasks: 'No tasks' },
     tagFilter: { showAll: 'Show all tasks' },
+    footer: {
+      about: 'About',
+      openSource: 'Open Source',
+      faqs: 'FAQs & Support',
+      privacy: 'Privacy Policy',
+      terms: 'Terms of Service',
+    },
     lang: { en: 'English', es: 'Spanish' },
   },
   es: {
@@ -100,6 +107,13 @@ const translations: Record<Language, any> = {
     priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
     taskList: { noTasks: 'No hay tareas' },
     tagFilter: { showAll: 'Mostrar todas las tareas' },
+    footer: {
+      about: 'Acerca de',
+      openSource: 'Código abierto',
+      faqs: 'Preguntas frecuentes y soporte',
+      privacy: 'Política de privacidad',
+      terms: 'Términos del servicio',
+    },
     lang: { en: 'Inglés', es: 'Español' },
   },
 };


### PR DESCRIPTION
## Summary
- add Footer component with key links
- integrate footer into layout and add translations

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ed1b57f84832c8236b3cb56fe3a29