### PR TITLE
Keep My Day tasks across days

### DIFF
--- a/components/Board/useBoard.ts
+++ b/components/Board/useBoard.ts
@@ -24,7 +24,6 @@ export default function useBoard({ mode }: UseBoardProps) {
   const { tasks, lists, order, moveTask, reorderTask } = useStore();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const { t } = useI18n();
-  const today = new Date().toISOString().slice(0, 10);
 
   const columns =
     mode === 'my-day'
@@ -49,7 +48,7 @@ export default function useBoard({ mode }: UseBoardProps) {
     return ids
       .map(id => tasks.find(t => t.id === id))
       .filter((t): t is Task => !!t)
-      .filter(t => (mode === 'my-day' ? t.plannedFor === today : true));
+      .filter(t => (mode === 'my-day' ? t.plannedFor !== null : true));
   }
 
   const handleDragStart = (event: DragStartEvent) => {

--- a/components/Header/useHeader.ts
+++ b/components/Header/useHeader.ts
@@ -14,8 +14,7 @@ export default function useHeader() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [showLang, setShowLang] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>('dark');
-  const today = new Date().toISOString().slice(0, 10);
-  const myDayCount = tasks.filter(t => t.plannedFor === today).length;
+  const myDayCount = tasks.filter(t => t.plannedFor !== null).length;
 
   useEffect(() => {
     const stored = localStorage.getItem('theme');


### PR DESCRIPTION
## Summary
- ensure My Day board shows tasks regardless of day change
- update header counter to include all My Day tasks

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689eda32d660832cb1eec8b7f9d194b5