### PR TITLE
feat: add favorite tags

### DIFF
--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Priority, Tag } from '../../lib/types';
 
 export interface UseAddTaskProps {
@@ -17,15 +17,31 @@ export default function useAddTask({
   tags: existingTags,
   addTag,
 }: UseAddTaskProps) {
+  const favoriteLabels = existingTags.filter(t => t.favorite).map(t => t.label);
   const [title, setTitle] = useState('');
-  const [tags, setTags] = useState<string[]>([]);
+  const [tags, setTags] = useState<string[]>(favoriteLabels);
   const [priority, setPriority] = useState<Priority>('medium');
+
+  useEffect(() => {
+    const favs = existingTags.filter(t => t.favorite).map(t => t.label);
+    setTags(prev => {
+      const existingLabels = existingTags.map(t => t.label);
+      const nonFavs = prev.filter(
+        t => !favs.includes(t) && existingLabels.includes(t)
+      );
+      return [...favs, ...nonFavs];
+    });
+  }, [existingTags]);
 
   const handleAdd = () => {
     if (!title.trim()) return;
+    const lastTag = tags[tags.length - 1];
     addTask({ title: title.trim(), tags, priority });
     setTitle('');
-    setTags([]);
+    const favs = existingTags.filter(t => t.favorite).map(t => t.label);
+    const newTags =
+      lastTag && !favs.includes(lastTag) ? [...favs, lastTag] : favs;
+    setTags(newTags);
   };
 
   const handleTagInputChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -36,7 +52,12 @@ export default function useAddTask({
         setTags([...tags, newTag]);
         if (!existingTags.find(t => t.label === newTag)) {
           const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
-          addTag({ id: crypto.randomUUID(), label: newTag, color });
+          addTag({
+            id: crypto.randomUUID(),
+            label: newTag,
+            color,
+            favorite: false,
+          });
         }
       }
       e.currentTarget.value = '';

--- a/components/TagFilter/TagFilter.tsx
+++ b/components/TagFilter/TagFilter.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Tag } from '../../lib/types';
 import { useI18n } from '../../lib/i18n';
+import { Star } from 'lucide-react';
 
 interface TagFilterProps {
   tags: Tag[];
@@ -8,6 +9,7 @@ interface TagFilterProps {
   toggleTag: (label: string) => void;
   showAll: () => void;
   removeTag: (label: string) => void;
+  toggleFavorite: (label: string) => void;
 }
 
 export default function TagFilter({
@@ -16,6 +18,7 @@ export default function TagFilter({
   toggleTag,
   showAll,
   removeTag,
+  toggleFavorite,
 }: TagFilterProps) {
   const { t } = useI18n();
   if (tags.length === 0) return null;
@@ -39,6 +42,28 @@ export default function TagFilter({
             className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs cursor-pointer"
           >
             <span className="mr-1 select-none">{tag.label}</span>
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                toggleFavorite(tag.label);
+              }}
+              aria-label={
+                tag.favorite
+                  ? t('actions.unfavoriteTag')
+                  : t('actions.favoriteTag')
+              }
+              title={
+                tag.favorite
+                  ? t('actions.unfavoriteTag')
+                  : t('actions.favoriteTag')
+              }
+              className="ml-1 flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/20"
+            >
+              <Star
+                className="h-3 w-3"
+                fill={tag.favorite ? 'currentColor' : 'none'}
+              />
+            </button>
             <button
               onClick={e => {
                 e.stopPropagation();

--- a/components/TaskItem/useTaskItem.ts
+++ b/components/TaskItem/useTaskItem.ts
@@ -35,7 +35,12 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
         updateTask(task.id, { tags: newTags });
         if (!allTags.find(t => t.label === newTag)) {
           const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
-          addTag({ id: crypto.randomUUID(), label: newTag, color });
+          addTag({
+            id: crypto.randomUUID(),
+            label: newTag,
+            color,
+            favorite: false,
+          });
         }
       }
       e.currentTarget.value = '';

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -14,6 +14,7 @@ export default function TasksView() {
     toggleTagFilter,
     resetTagFilter,
     removeTag,
+    toggleFavoriteTag,
     confirmRemoveTag,
     cancelRemoveTag,
   } = actions;
@@ -31,6 +32,7 @@ export default function TasksView() {
         toggleTag={toggleTagFilter}
         showAll={resetTagFilter}
         removeTag={removeTag}
+        toggleFavorite={toggleFavoriteTag}
       />
       <TaskList tasks={tasks} />
       {tagToRemove && (

--- a/components/TasksView/useTasksView.ts
+++ b/components/TasksView/useTasksView.ts
@@ -68,6 +68,7 @@ export default function useTasksView() {
       toggleTagFilter,
       resetTagFilter,
       removeTag,
+      toggleFavoriteTag: store.toggleFavoriteTag,
       confirmRemoveTag,
       cancelRemoveTag,
     },

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -19,6 +19,8 @@ const translations: Record<Language, any> = {
       toggleTheme: 'Toggle theme',
       language: 'Select language',
       removeTag: 'Remove tag',
+      favoriteTag: 'Add tag to favorites',
+      unfavoriteTag: 'Remove tag from favorites',
     },
     confirmDelete: {
       message:
@@ -76,6 +78,8 @@ const translations: Record<Language, any> = {
       toggleTheme: 'Cambiar tema',
       language: 'Seleccionar idioma',
       removeTag: 'Eliminar etiqueta',
+      favoriteTag: 'Marcar etiqueta como favorita',
+      unfavoriteTag: 'Quitar etiqueta de favoritas',
     },
     confirmDelete: {
       message:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type Tag = {
   id: string;
   label: string;
   color: string;
+  favorite?: boolean;
 };
 
 export type Task = {


### PR DESCRIPTION
## Summary
- allow tags to be marked as favorites and persist them
- surface favorite tags when adding tasks
- add UI to toggle favorites for existing tags

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a01832cb78832c996efca8376b6659