### PR TITLE
Add About page with project details

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { useI18n } from '../../lib/i18n';
+
+export default function AboutPage() {
+  const { t } = useI18n();
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-4 p-4">
+      <h1 className="text-2xl font-bold">{t('aboutPage.title')}</h1>
+      <p>{t('aboutPage.intro')}</p>
+      <ul className="list-disc space-y-1 pl-6">
+        <li>{t('aboutPage.features.myDay')}</li>
+        <li>{t('aboutPage.features.myTasks')}</li>
+        <li>{t('aboutPage.features.dragDrop')}</li>
+        <li>{t('aboutPage.features.export')}</li>
+        <li>{t('aboutPage.features.privacy')}</li>
+      </ul>
+      <p>{t('aboutPage.personal')}</p>
+      <p>{t('aboutPage.productivity')}</p>
+      <p>
+        {t('aboutPage.freeOpenSource')}{' '}
+        <a
+          href="https://github.com/AntonioHCervantes/local-quick-planner"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:no-underline"
+        >
+          {t('footer.openSource')}
+        </a>
+        .
+      </p>
+      <p>
+        {t('aboutPage.learnMore')}{' '}
+        <Link
+          href="/faqs"
+          className="underline hover:no-underline"
+        >
+          {t('footer.faqs')}
+        </Link>
+        ,{' '}
+        <Link
+          href="/privacy"
+          className="underline hover:no-underline"
+        >
+          {t('footer.privacy')}
+        </Link>{' '}
+        {t('aboutPage.and')}{' '}
+        <Link
+          href="/terms"
+          className="underline hover:no-underline"
+        >
+          {t('footer.terms')}
+        </Link>
+        .
+      </p>
+    </main>
+  );
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -61,6 +61,26 @@ const translations: Record<Language, any> = {
       privacy: 'Privacy Policy',
       terms: 'Terms of Service',
     },
+    aboutPage: {
+      title: 'About Local Quick Planner',
+      intro:
+        'Local Quick Planner is a simple, fast, and free tool to organize your tasks right in your browser.',
+      features: {
+        myDay: 'Plan your daily priorities with the "My Day" view.',
+        myTasks: 'Organize projects with the "My Tasks" Kanban board.',
+        dragDrop: 'Move tasks effortlessly with drag and drop.',
+        export: 'Back up or transfer your data with export and import options.',
+        privacy:
+          'Keep all your data on your device; nothing is sent to a server.',
+      },
+      personal:
+        'This tool is focused on personal planning and is not intended for teams or multi-user workflows.',
+      productivity:
+        'It helps you stay organized and improve your productivity.',
+      freeOpenSource: 'Local Quick Planner is completely free and open source.',
+      learnMore: 'Learn more in our',
+      and: 'and',
+    },
     lang: { en: 'English', es: 'Spanish' },
   },
   es: {
@@ -113,6 +133,28 @@ const translations: Record<Language, any> = {
       faqs: 'Preguntas frecuentes y soporte',
       privacy: 'Política de privacidad',
       terms: 'Términos del servicio',
+    },
+    aboutPage: {
+      title: 'Acerca de Local Quick Planner',
+      intro:
+        'Local Quick Planner es una herramienta simple, rápida y gratuita para organizar tus tareas directamente en tu navegador.',
+      features: {
+        myDay: 'Planifica tus prioridades diarias con la vista "Mi Día".',
+        myTasks: 'Organiza tus proyectos con el tablero Kanban "Mis Tareas".',
+        dragDrop: 'Mueve las tareas fácilmente con drag and drop.',
+        export:
+          'Haz copias de seguridad o traslada tus datos con las opciones de exportar e importar.',
+        privacy:
+          'Mantén todos tus datos en tu dispositivo; nada se envía a servidores.',
+      },
+      personal:
+        'Esta herramienta está enfocada en la planificación personal y no está pensada para equipos ni flujos multiusuario.',
+      productivity:
+        'Te ayuda a mantener el enfoque y mejorar tu productividad.',
+      freeOpenSource:
+        'Local Quick Planner es totalmente gratuito y de código abierto.',
+      learnMore: 'Obtén más información en nuestras',
+      and: 'y',
     },
     lang: { en: 'Inglés', es: 'Español' },
   },


### PR DESCRIPTION
## Summary
- create About page that displays project details
- add English and Spanish translations for the About page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ed76b4a94832cbdfbd46c363cd52c