### PR TITLE
feat: add in-progress shortcut for My Day tasks

### DIFF
--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Check, Trash2 } from 'lucide-react';
+import { Check, Trash2, Play } from 'lucide-react';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
 
 const priorityColors = {
@@ -11,7 +11,7 @@ const priorityColors = {
 export default function TaskCard(props: UseTaskCardProps) {
   const { state, actions } = useTaskCard(props);
   const { attributes, listeners, setNodeRef, style, t } = state;
-  const { markDone, getTagColor, deleteTask } = actions;
+  const { markInProgress, markDone, getTagColor, deleteTask } = actions;
   const { task, mode } = props;
 
   return (
@@ -24,32 +24,59 @@ export default function TaskCard(props: UseTaskCardProps) {
     >
       <div
         className={`flex justify-between ${
-          mode === 'my-day' && task.dayStatus === 'done'
-            ? 'items-start'
-            : 'items-center'
+          mode === 'my-day' ? 'items-start' : 'items-center'
         }`}
       >
         <span className="flex-1 mr-2">{task.title}</span>
-        <div className="flex items-center gap-2">
-          {task.dayStatus !== 'done' && (
-            <button
-              onClick={markDone}
-              aria-label={t('taskCard.markDone')}
-              title={t('taskCard.markDone')}
-              className="text-green-400 hover:text-green-500"
-            >
-              <Check className="h-4 w-4" />
-            </button>
-          )}
-          {mode === 'my-day' && task.dayStatus === 'done' && (
-            <button
-              onClick={deleteTask}
-              aria-label={t('taskCard.deleteTask')}
-              title={t('taskCard.deleteTask')}
-              className="text-red-400 hover:text-red-500"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
+        <div
+          className={`flex gap-2 ${
+            mode === 'my-day' ? 'items-start' : 'items-center'
+          }`}
+        >
+          {mode === 'my-day' ? (
+            <>
+              {task.dayStatus === 'todo' && (
+                <button
+                  onClick={markInProgress}
+                  aria-label={t('taskCard.markInProgress')}
+                  title={t('taskCard.markInProgress')}
+                  className="text-blue-400 hover:text-blue-500"
+                >
+                  <Play className="h-4 w-4" />
+                </button>
+              )}
+              {task.dayStatus === 'doing' && (
+                <button
+                  onClick={markDone}
+                  aria-label={t('taskCard.markDone')}
+                  title={t('taskCard.markDone')}
+                  className="text-green-400 hover:text-green-500"
+                >
+                  <Check className="h-4 w-4" />
+                </button>
+              )}
+              {task.dayStatus === 'done' && (
+                <button
+                  onClick={deleteTask}
+                  aria-label={t('taskCard.deleteTask')}
+                  title={t('taskCard.deleteTask')}
+                  className="text-red-400 hover:text-red-500"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </>
+          ) : (
+            task.dayStatus !== 'done' && (
+              <button
+                onClick={markDone}
+                aria-label={t('taskCard.markDone')}
+                title={t('taskCard.markDone')}
+                className="text-green-400 hover:text-green-500"
+              >
+                <Check className="h-4 w-4" />
+              </button>
+            )
           )}
         </div>
       </div>

--- a/components/TaskCard/useTaskCard.ts
+++ b/components/TaskCard/useTaskCard.ts
@@ -29,6 +29,12 @@ export default function useTaskCard({
   const { moveTask, removeTask, tags: allTags } = useStore();
   const { t } = useI18n();
 
+  const markInProgress = () => {
+    if (task.dayStatus !== 'doing') {
+      moveTask(task.id, { dayStatus: 'doing' });
+    }
+  };
+
   const markDone = () => {
     if (task.dayStatus !== 'done') {
       moveTask(task.id, { dayStatus: 'done' });
@@ -46,6 +52,6 @@ export default function useTaskCard({
 
   return {
     state: { attributes, listeners, setNodeRef, style, t, allTags },
-    actions: { markDone, getTagColor, deleteTask },
+    actions: { markInProgress, markDone, getTagColor, deleteTask },
   } as const;
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -44,6 +44,7 @@ const translations: Record<Language, any> = {
       addButton: 'Add',
     },
     taskCard: {
+      markInProgress: 'Move to In Progress',
       markDone: 'Mark as done',
       deleteTask: 'Delete task',
     },
@@ -103,6 +104,7 @@ const translations: Record<Language, any> = {
       addButton: 'Añadir',
     },
     taskCard: {
+      markInProgress: 'Mover a En progreso',
       markDone: 'Marcar como completada',
       deleteTask: 'Eliminar tarea',
     },


### PR DESCRIPTION
## Summary
- add in-progress action for My Day tasks
- update task actions styling and translations

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a01c95c1d4832caae9792869571b6e