### PR TITLE
feat: reorder tasks with drag and drop

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -1,8 +1,10 @@
 'use client';
-import { CalendarPlus, CalendarX, Trash2 } from 'lucide-react';
+import { CalendarPlus, CalendarX, Trash2, GripVertical } from 'lucide-react';
 import { Priority } from '../../lib/types';
 import { useI18n } from '../../lib/i18n';
 import useTaskItem, { UseTaskItemProps } from './useTaskItem';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 export default function TaskItem({ taskId }: UseTaskItemProps) {
   const { state, actions } = useTaskItem({ taskId });
@@ -21,112 +23,136 @@ export default function TaskItem({ taskId }: UseTaskItemProps) {
   } = actions as any; // when task undefined, actions is empty
   const { t } = useI18n();
 
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: taskId, disabled: !task });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   if (!task) {
     return null;
   }
 
   return (
     <div
-      className={`flex flex-col gap-2 rounded p-2 ${
-        task.plannedFor
-          ? 'bg-yellow-100 dark:bg-[#bb871e]'
-          : 'bg-gray-100 dark:bg-gray-800'
-      }`}
+      ref={setNodeRef}
+      style={style}
+      className="flex"
     >
-      <div className="flex items-center gap-2">
-        {isEditing ? (
-          <input
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-            onBlur={saveTitle}
-            onKeyDown={handleTitleKeyDown}
-            className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
-            autoFocus
-          />
-        ) : (
-          <p
-            className="flex-1"
-            onClick={startEditing}
-          >
-            {task.title}
-          </p>
-        )}
-        <select
-          value={task.priority ?? ''}
-          onChange={e =>
-            updateTask(task.id, {
-              priority: e.target.value as Priority,
-            })
-          }
-          className="rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
-        >
-          <option value="low">{t('priority.low')}</option>
-          <option value="medium">{t('priority.medium')}</option>
-          <option value="high">{t('priority.high')}</option>
-        </select>
-        <button
-          onClick={() => toggleMyDay(task.id)}
-          aria-label={
-            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-          }
-          title={
-            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-          }
-          className={`rounded p-1 focus:ring ${
-            task.plannedFor
-              ? 'bg-yellow-500 text-black hover:bg-yellow-600'
-              : 'bg-blue-600 text-white hover:bg-blue-700'
-          }`}
-        >
-          {task.plannedFor ? (
-            <CalendarX className="h-4 w-4" />
-          ) : (
-            <CalendarPlus className="h-4 w-4" />
-          )}
-        </button>
-        <button
-          onClick={() => removeTask(task.id)}
-          aria-label={t('taskItem.deleteTask')}
-          title={t('taskItem.deleteTask')}
-          className="rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:ring"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
+      <div
+        {...attributes}
+        {...listeners}
+        className="flex items-center pr-2 cursor-grab"
+      >
+        <GripVertical className="h-4 w-4 text-gray-500" />
       </div>
-      <div className="flex items-center gap-2">
-        <div className="flex flex-wrap gap-1">
-          {task.tags.map(tag => (
-            <span
-              key={tag}
-              style={{ backgroundColor: getTagColor(tag) }}
-              className="text-xs px-2 py-1 rounded-full"
-            >
-              {tag}
-              <button
-                onClick={() => removeTag(tag)}
-                aria-label={t('actions.removeTag')}
-                title={t('actions.removeTag')}
-                className="ml-1 text-red-500"
-              >
-                x
-              </button>
-            </span>
-          ))}
-        </div>
-        <input
-          onKeyDown={handleTagInputChange}
-          className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
-          placeholder={t('taskItem.tagPlaceholder')}
-          list="existing-tags"
-        />
-        <datalist id="existing-tags">
-          {allTags.map(tag => (
-            <option
-              key={tag.id}
-              value={tag.label}
+      <div
+        className={`flex flex-col gap-2 rounded p-2 flex-1 ${
+          task.plannedFor
+            ? 'bg-yellow-100 dark:bg-[#bb871e]'
+            : 'bg-gray-100 dark:bg-gray-800'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          {isEditing ? (
+            <input
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              onBlur={saveTitle}
+              onKeyDown={handleTitleKeyDown}
+              className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
+              autoFocus
             />
-          ))}
-        </datalist>
+          ) : (
+            <p
+              className="flex-1"
+              onClick={startEditing}
+            >
+              {task.title}
+            </p>
+          )}
+          <select
+            value={task.priority ?? ''}
+            onChange={e =>
+              updateTask(task.id, {
+                priority: e.target.value as Priority,
+              })
+            }
+            className="rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
+          >
+            <option value="low">{t('priority.low')}</option>
+            <option value="medium">{t('priority.medium')}</option>
+            <option value="high">{t('priority.high')}</option>
+          </select>
+          <button
+            onClick={() => toggleMyDay(task.id)}
+            aria-label={
+              task.plannedFor
+                ? t('taskItem.removeMyDay')
+                : t('taskItem.addMyDay')
+            }
+            title={
+              task.plannedFor
+                ? t('taskItem.removeMyDay')
+                : t('taskItem.addMyDay')
+            }
+            className={`rounded p-1 focus:ring ${
+              task.plannedFor
+                ? 'bg-yellow-500 text-black hover:bg-yellow-600'
+                : 'bg-blue-600 text-white hover:bg-blue-700'
+            }`}
+          >
+            {task.plannedFor ? (
+              <CalendarX className="h-4 w-4" />
+            ) : (
+              <CalendarPlus className="h-4 w-4" />
+            )}
+          </button>
+          <button
+            onClick={() => removeTask(task.id)}
+            aria-label={t('taskItem.deleteTask')}
+            title={t('taskItem.deleteTask')}
+            className="rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:ring"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-wrap gap-1">
+            {task.tags.map(tag => (
+              <span
+                key={tag}
+                style={{ backgroundColor: getTagColor(tag) }}
+                className="text-xs px-2 py-1 rounded-full"
+              >
+                {tag}
+                <button
+                  onClick={() => removeTag(tag)}
+                  aria-label={t('actions.removeTag')}
+                  title={t('actions.removeTag')}
+                  className="ml-1 text-red-500"
+                >
+                  x
+                </button>
+              </span>
+            ))}
+          </div>
+          <input
+            onKeyDown={handleTagInputChange}
+            className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
+            placeholder={t('taskItem.tagPlaceholder')}
+            list="existing-tags"
+          />
+          <datalist id="existing-tags">
+            {allTags.map(tag => (
+              <option
+                key={tag.id}
+                value={tag.label}
+              />
+            ))}
+          </datalist>
+        </div>
       </div>
     </div>
   );

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -1,25 +1,42 @@
 'use client';
+import { DndContext } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import TaskItem from '../TaskItem/TaskItem';
 import { useI18n } from '../../lib/i18n';
 import useTaskList, { UseTaskListProps } from './useTaskList';
 
 export default function TaskList(props: UseTaskListProps) {
-  const { state } = useTaskList(props);
-  const { sorted } = state;
+  const { tasks } = props;
+  const { state, actions } = useTaskList(props);
+  const { sensors } = state;
+  const { handleDragEnd } = actions;
   const { t } = useI18n();
   return (
-    <div className="space-y-2 p-4">
-      {sorted.map(task => (
-        <TaskItem
-          key={task.id}
-          taskId={task.id}
-        />
-      ))}
-      {sorted.length === 0 && (
-        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-          {t('taskList.noTasks')}
-        </p>
-      )}
-    </div>
+    <DndContext
+      sensors={sensors}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={tasks.map(t => t.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-2 p-4">
+          {tasks.map(task => (
+            <TaskItem
+              key={task.id}
+              taskId={task.id}
+            />
+          ))}
+          {tasks.length === 0 && (
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+              {t('taskList.noTasks')}
+            </p>
+          )}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }

--- a/components/TasksView/useTasksView.ts
+++ b/components/TasksView/useTasksView.ts
@@ -60,8 +60,22 @@ export default function useTasksView() {
     });
   }, [store.tasks, activeTags]);
 
+  const orderedTasks = useMemo(() => {
+    const ids = [
+      ...(store.order['priority-high'] || []),
+      ...(store.order['priority-medium'] || []),
+      ...(store.order['priority-low'] || []),
+    ];
+    const map = new Map(filteredTasks.map(t => [t.id, t]));
+    const list = ids
+      .map(id => map.get(id))
+      .filter((t): t is (typeof filteredTasks)[number] => !!t);
+    const remaining = filteredTasks.filter(t => !ids.includes(t.id));
+    return [...list, ...remaining];
+  }, [filteredTasks, store.order]);
+
   return {
-    state: { tasks: filteredTasks, tags: store.tags, activeTags, tagToRemove },
+    state: { tasks: orderedTasks, tags: store.tags, activeTags, tagToRemove },
     actions: {
       addTask: store.addTask,
       addTag: store.addTag,


### PR DESCRIPTION
## Summary
- allow rearranging tasks in My Tasks via drag-and-drop with a handle
- persist custom order and update priority when moving between zones

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a01d62d870832cbfd5594e121fb84e