### PR TITLE
Highlight newly added task

### DIFF
--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -7,7 +7,7 @@ export interface UseAddTaskProps {
     title: string;
     tags: string[];
     priority: Priority;
-  }) => void;
+  }) => string;
   tags: Tag[];
   addTag: (tag: Tag) => void;
 }

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -6,7 +6,11 @@ import useTaskItem, { UseTaskItemProps } from './useTaskItem';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function TaskItem({ taskId }: UseTaskItemProps) {
+interface TaskItemProps extends UseTaskItemProps {
+  highlighted?: boolean;
+}
+
+export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
   const { state, actions } = useTaskItem({ taskId });
   const { task, isEditing, title, allTags } = state;
   const {
@@ -52,7 +56,7 @@ export default function TaskItem({ taskId }: UseTaskItemProps) {
           task.plannedFor
             ? 'bg-yellow-100 dark:bg-[#bb871e]'
             : 'bg-gray-100 dark:bg-gray-800'
-        }`}
+        } ${highlighted ? 'ring-2 ring-blue-500' : ''}`}
       >
         <div className="flex items-center gap-2">
           {isEditing ? (

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -8,9 +8,12 @@ import TaskItem from '../TaskItem/TaskItem';
 import { useI18n } from '../../lib/i18n';
 import useTaskList, { UseTaskListProps } from './useTaskList';
 
-export default function TaskList(props: UseTaskListProps) {
-  const { tasks } = props;
-  const { state, actions } = useTaskList(props);
+interface TaskListProps extends UseTaskListProps {
+  highlightedId?: string | null;
+}
+
+export default function TaskList({ tasks, highlightedId }: TaskListProps) {
+  const { state, actions } = useTaskList({ tasks });
   const { sensors } = state;
   const { handleDragEnd } = actions;
   const { t } = useI18n();
@@ -28,6 +31,7 @@ export default function TaskList(props: UseTaskListProps) {
             <TaskItem
               key={task.id}
               taskId={task.id}
+              highlighted={task.id === highlightedId}
             />
           ))}
           {tasks.length === 0 && (

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '../../lib/i18n';
 
 export default function TasksView() {
   const { state, actions } = useTasksView();
-  const { tasks, tags, activeTags, tagToRemove } = state;
+  const { tasks, tags, activeTags, tagToRemove, highlightedId } = state;
   const {
     addTask,
     addTag,
@@ -34,7 +34,10 @@ export default function TasksView() {
         removeTag={removeTag}
         toggleFavorite={toggleFavoriteTag}
       />
-      <TaskList tasks={tasks} />
+      <TaskList
+        tasks={tasks}
+        highlightedId={highlightedId}
+      />
       {tagToRemove && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">

--- a/components/TasksView/useTasksView.ts
+++ b/components/TasksView/useTasksView.ts
@@ -2,11 +2,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useStore } from '../../lib/store';
 import { loadState } from '../../lib/storage';
+import { Priority } from '../../lib/types';
 
 export default function useTasksView() {
   const store = useStore();
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [tagToRemove, setTagToRemove] = useState<string | null>(null);
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
 
   useEffect(() => {
     if (store.tags.length === 0) {
@@ -75,9 +77,24 @@ export default function useTasksView() {
   }, [filteredTasks, store.order]);
 
   return {
-    state: { tasks: orderedTasks, tags: store.tags, activeTags, tagToRemove },
+    state: {
+      tasks: orderedTasks,
+      tags: store.tags,
+      activeTags,
+      tagToRemove,
+      highlightedId,
+    },
     actions: {
-      addTask: store.addTask,
+      addTask: (input: {
+        title: string;
+        tags: string[];
+        priority: Priority;
+      }) => {
+        const id = store.addTask(input);
+        setHighlightedId(id);
+        setTimeout(() => setHighlightedId(null), 3000);
+        return id;
+      },
       addTag: store.addTag,
       toggleTagFilter,
       resetTagFilter,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -33,7 +33,7 @@ type Store = PersistedState & {
     title: string;
     tags: string[];
     priority: Priority;
-  }) => void;
+  }) => string;
   addTag: (tag: Tag) => void;
   removeTag: (label: string) => void;
   toggleFavoriteTag: (label: string) => void;
@@ -145,6 +145,7 @@ export const useStore = create<Store>((set, get) => ({
       };
     });
     saveState(get());
+    return id;
   },
   addTag: tag => {
     set(state => {


### PR DESCRIPTION
## Summary
- highlight newly added task for a few seconds in the My Tasks list
- track highlighted task ID in the tasks view and pass to task list/items
- return new task ID from store for highlight handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a021fd608c832c807826559bf3eb52