### PR TITLE
Add site title metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,13 @@
-'use client';
 import './globals.css';
 import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
 import Header from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
 import { I18nProvider } from '../lib/i18n';
+
+export const metadata: Metadata = {
+  title: 'Local Quick Planner',
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- add site-wide metadata title for browser tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a026f2c0a8832ca187d5f807287c2a