### PR TITLE
Limit add tag input width in task view

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -144,7 +144,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           </div>
           <input
             onKeyDown={handleTagInputChange}
-            className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
+            className="w-[200px] rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
             placeholder={t('taskItem.tagPlaceholder')}
             list="existing-tags"
           />


### PR DESCRIPTION
## Summary
- Limit "Add tag" input width beside tags to 200px so it no longer stretches across task cards

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1692a763c832cb4eec3b2efca9dd4