### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -33,9 +33,6 @@ export default function PrivacyPage() {
         </Link>
         .
       </p>
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t('privacyPage.effectiveDate')}
-      </p>
     </div>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -42,9 +42,6 @@ export default function TermsPage() {
         </Link>
         .
       </p>
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t('termsPage.effectiveDate')}
-      </p>
     </div>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -159,7 +159,6 @@ const translations: Record<Language, any> = {
         title: 'Contact',
         description: 'If you have questions, reach out through GitHub issues.',
       },
-      effectiveDate: 'This policy is effective as of July 1, 2024.',
     },
     termsPage: {
       title: 'Terms of Service',
@@ -187,7 +186,6 @@ const translations: Record<Language, any> = {
         title: 'Contact',
         description: 'If you have questions, reach out through GitHub issues.',
       },
-      effectiveDate: 'These terms are effective as of July 1, 2024.',
     },
     lang: { en: 'English', es: 'Spanish' },
   },
@@ -343,7 +341,6 @@ const translations: Record<Language, any> = {
         description:
           'Si tienes preguntas, contáctanos mediante las issues de GitHub.',
       },
-      effectiveDate: 'Esta política es efectiva desde el 1 de julio de 2024.',
     },
     termsPage: {
       title: 'Términos del servicio',
@@ -373,8 +370,6 @@ const translations: Record<Language, any> = {
         description:
           'Si tienes preguntas, contáctanos mediante las issues de GitHub.',
       },
-      effectiveDate:
-        'Estos términos son efectivos desde el 1 de julio de 2024.',
     },
     lang: { en: 'Inglés', es: 'Español' },
   },


### PR DESCRIPTION
## Summary
- add privacy policy page explaining local data storage and lack of tracking
- add terms of service page covering usage, liability, and changes
- provide translations for both pages in English and Spanish

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a33bee1768832cb1a8e3ca46be9192