### PR TITLE
Refine My Day light mode highlight color

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
             className="flex items-center hover:underline focus:underline"
           >
             {t('nav.myDay')}
-            <span className="ml-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs text-current dark:bg-[rgb(62,74,113)]">
+            <span className="ml-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs text-current dark:bg-[rgb(62,74,113)]">
               {myDayCount}
             </span>
           </Link>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -54,7 +54,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
       <div
         className={`flex flex-col gap-2 rounded p-2 flex-1 ${
           task.plannedFor
-            ? 'bg-yellow-100 dark:bg-[rgb(62,74,113)]'
+            ? 'bg-blue-100 dark:bg-[rgb(62,74,113)]'
             : 'bg-gray-100 dark:bg-gray-800'
         } ${highlighted ? 'ring-2 ring-blue-500' : ''}`}
       >


### PR DESCRIPTION
## Summary
- Switch My Day task highlight in light mode to a softer blue
- Update header counter to match new My Day color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a584c6f78c832c9e4bfc3d6c39ee4f