### PR TITLE
feat: add in-progress task timer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import Header from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
 import { I18nProvider } from '../lib/i18n';
+import { Toaster } from 'react-hot-toast';
 
 export const metadata: Metadata = {
   title: 'Local Quick Planner',
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />
+          <Toaster />
         </I18nProvider>
       </body>
     </html>

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Check, Trash2, Play } from 'lucide-react';
+import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
 
 const priorityColors = {
@@ -91,6 +92,9 @@ export default function TaskCard(props: UseTaskCardProps) {
           </span>
         ))}
       </div>
+      {mode === 'my-day' && task.dayStatus === 'doing' && (
+        <Timer taskTitle={task.title} />
+      )}
     </div>
   );
 }

--- a/components/TaskCard/Timer.tsx
+++ b/components/TaskCard/Timer.tsx
@@ -1,0 +1,114 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Play, Pause } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { useI18n } from '../../lib/i18n';
+
+const options = [
+  { label: '5m', value: 5 * 60 },
+  { label: '15m', value: 15 * 60 },
+  { label: '30m', value: 30 * 60 },
+  { label: '1h', value: 60 * 60 },
+];
+
+interface TimerProps {
+  taskTitle: string;
+}
+
+export default function Timer({ taskTitle }: TimerProps) {
+  const [duration, setDuration] = useState(options[0].value);
+  const [timeLeft, setTimeLeft] = useState(options[0].value);
+  const [running, setRunning] = useState(false);
+  const { t } = useI18n();
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
+    if (running && timeLeft > 0) {
+      interval = setInterval(() => {
+        setTimeLeft(t => t - 1);
+      }, 1000);
+    } else if (running && timeLeft === 0) {
+      setRunning(false);
+      toast(t('timer.finished').replace('{task}', taskTitle));
+      playSound();
+    }
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [running, timeLeft, taskTitle, t]);
+
+  const playSound = () => {
+    try {
+      const ctx = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+      oscillator.type = 'sine';
+      oscillator.frequency.setValueAtTime(880, ctx.currentTime);
+      gain.gain.setValueAtTime(0.05, ctx.currentTime);
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+      oscillator.start();
+      oscillator.stop(ctx.currentTime + 0.5);
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  const handleDurationChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newDuration = Number(e.target.value);
+    setDuration(newDuration);
+    setTimeLeft(newDuration);
+    setRunning(false);
+  };
+
+  const toggle = () => {
+    if (timeLeft === 0) setTimeLeft(duration);
+    setRunning(r => !r);
+  };
+
+  const progress = duration > 0 ? ((duration - timeLeft) / duration) * 100 : 0;
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="flex items-center gap-2">
+        <select
+          value={duration}
+          onChange={handleDurationChange}
+          className="rounded bg-gray-200 p-1 text-sm dark:bg-gray-700"
+        >
+          {options.map(o => (
+            <option
+              key={o.value}
+              value={o.value}
+            >
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={toggle}
+          aria-label={running ? t('timer.pause') : t('timer.start')}
+          title={running ? t('timer.pause') : t('timer.start')}
+          className="rounded bg-blue-500 p-1 text-white hover:brightness-110 focus:ring"
+        >
+          {running ? (
+            <Pause className="h-4 w-4" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+        </button>
+        <span className="w-12 text-right text-xs">
+          {Math.floor(timeLeft / 60)}:
+          {(timeLeft % 60).toString().padStart(2, '0')}
+        </span>
+      </div>
+      <div className="h-2 w-full rounded bg-gray-300 dark:bg-gray-700">
+        <div
+          className="h-2 rounded bg-blue-500 dark:bg-blue-400"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -54,6 +54,11 @@ const translations: Record<Language, any> = {
       deleteTask: 'Delete task',
       tagPlaceholder: 'Add tag',
     },
+    timer: {
+      start: 'Start timer',
+      pause: 'Pause timer',
+      finished: 'Time for "{task}" finished',
+    },
     priority: { low: 'Low', medium: 'Medium', high: 'High' },
     taskList: { noTasks: 'No tasks' },
     tagFilter: {
@@ -185,6 +190,11 @@ const translations: Record<Language, any> = {
       addMyDay: 'Agregar a Mi Día',
       deleteTask: 'Eliminar tarea',
       tagPlaceholder: 'Añadir etiqueta',
+    },
+    timer: {
+      start: 'Iniciar temporizador',
+      pause: 'Pausar temporizador',
+      finished: 'Tiempo para "{task}" terminado',
     },
     priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
     taskList: { noTasks: 'No hay tareas' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^14.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.4.1",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -1850,7 +1851,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3166,6 +3166,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4918,6 +4927,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "^14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.4.1",
     "zustand": "^4.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add react-hot-toast for toast notifications
- show selectable timer on in-progress tasks in My Day
- notify user with sound and toast when timer ends
- localize timer messages for supported languages

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a57227c5d0832c9c412971dfb4d0a6