### PR TITLE
Persist language preference and default to browser locale

### DIFF
--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -404,14 +404,17 @@ function getTranslation(lang: Language, key: string): string {
 }
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [language, setLanguage] = useState<Language>('en');
-
-  useEffect(() => {
-    const stored = localStorage.getItem('lang');
-    if (stored === 'en' || stored === 'es') {
-      setLanguage(stored);
+  const [language, setLanguage] = useState<Language>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('lang');
+      if (stored === 'en' || stored === 'es') {
+        return stored;
+      }
+      const browser = navigator.language.split('-')[0];
+      return browser === 'es' ? 'es' : 'en';
     }
-  }, []);
+    return 'en';
+  });
 
   useEffect(() => {
     document.documentElement.lang = language;


### PR DESCRIPTION
## Summary
- derive initial app language from stored preference or browser settings
- keep language choice in localStorage and set document language

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a95cb5f678832c8bc438ee9d9c680b