### PR TITLE
Align new task highlight with My Day color

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -56,7 +56,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           task.plannedFor
             ? 'bg-blue-100 dark:bg-[rgb(62,74,113)]'
             : 'bg-gray-100 dark:bg-gray-800'
-        } ${highlighted ? 'ring-2 ring-blue-100 dark:ring-[rgb(62,74,113)]' : ''}`}
+        } ${highlighted ? 'ring-2 ring-[#57886C]' : ''}`}
       >
         <div className="flex items-center gap-2">
           {isEditing ? (

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -56,7 +56,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           task.plannedFor
             ? 'bg-blue-100 dark:bg-[rgb(62,74,113)]'
             : 'bg-gray-100 dark:bg-gray-800'
-        } ${highlighted ? 'ring-2 ring-[#57886C]' : ''}`}
+        } ${highlighted ? 'ring-2 ring-[#57886C] bg-[#57886C] text-white' : ''}`}
       >
         <div className="flex items-center gap-2">
           {isEditing ? (

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -56,7 +56,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           task.plannedFor
             ? 'bg-blue-100 dark:bg-[rgb(62,74,113)]'
             : 'bg-gray-100 dark:bg-gray-800'
-        } ${highlighted ? 'ring-2 ring-blue-500' : ''}`}
+        } ${highlighted ? 'ring-2 ring-blue-100 dark:ring-[rgb(62,74,113)]' : ''}`}
       >
         <div className="flex items-center gap-2">
           {isEditing ? (


### PR DESCRIPTION
## Summary
- update new task highlight ring color to match My Day task background in light and dark modes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaab82b260832c975b6236a2d017d5