### PR TITLE
Fix Enter key removing selected tag when adding tasks

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -124,6 +124,7 @@ export default function AddTask(props: UseAddTaskProps) {
               >
                 <span className="mr-1 select-none">{tag}</span>
                 <button
+                  type="button"
                   onClick={() => removeTag(tag)}
                   aria-label={t('actions.removeTag')}
                   title={t('actions.removeTag')}


### PR DESCRIPTION
## Summary
- ensure tag delete buttons in Add Task form don't trigger form submit

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaabefab24832c87308d58bf7c0ca3