### PR TITLE
Add automatic tag selection from helper

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -8,8 +8,14 @@ import useAddTask, { UseAddTaskProps } from './useAddTask';
 export default function AddTask(props: UseAddTaskProps) {
   const { state, actions } = useAddTask(props);
   const { title, tags, priority, existingTags } = state;
-  const { setTitle, setPriority, handleAdd, handleTagInputChange, removeTag } =
-    actions;
+  const {
+    setTitle,
+    setPriority,
+    handleAdd,
+    handleTagInputChange,
+    handleExistingTagSelect,
+    removeTag,
+  } = actions;
   const { t, language } = useI18n();
   const recognitionRef = useRef<any>(null);
   const [isListening, setIsListening] = useState(false);
@@ -104,6 +110,7 @@ export default function AddTask(props: UseAddTaskProps) {
           <input
             id="task-tags"
             onKeyDown={handleTagInputChange}
+            onChange={handleExistingTagSelect}
             className="rounded bg-gray-200 p-2 text-sm focus:ring dark:bg-gray-800"
             placeholder={t('addTask.tagsPlaceholder')}
             list="existing-tags"

--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -44,23 +44,35 @@ export default function useAddTask({
     setTags(newTags);
   };
 
+  const addTagFromValue = (value: string) => {
+    const newTag = value.trim();
+    if (newTag && !tags.includes(newTag)) {
+      setTags([...tags, newTag]);
+      if (!existingTags.find(t => t.label === newTag)) {
+        const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
+        addTag({
+          id: crypto.randomUUID(),
+          label: newTag,
+          color,
+          favorite: false,
+        });
+      }
+    }
+  };
+
   const handleTagInputChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
-      const newTag = e.currentTarget.value.trim();
-      if (newTag && !tags.includes(newTag)) {
-        setTags([...tags, newTag]);
-        if (!existingTags.find(t => t.label === newTag)) {
-          const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
-          addTag({
-            id: crypto.randomUUID(),
-            label: newTag,
-            color,
-            favorite: false,
-          });
-        }
-      }
+      addTagFromValue(e.currentTarget.value);
       e.currentTarget.value = '';
+    }
+  };
+
+  const handleExistingTagSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (existingTags.some(tag => tag.label === value)) {
+      addTagFromValue(value);
+      e.target.value = '';
     }
   };
 
@@ -75,6 +87,7 @@ export default function useAddTask({
       setPriority,
       handleAdd,
       handleTagInputChange,
+      handleExistingTagSelect,
       removeTag,
     },
   } as const;

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -22,6 +22,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
   const {
     setTitle,
     handleTagInputChange,
+    handleExistingTagSelect,
     removeTag,
     getTagColor,
     startEditing,
@@ -159,6 +160,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
             <>
               <input
                 onKeyDown={handleTagInputChange}
+                onChange={handleExistingTagSelect}
                 className="w-[200px] rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700"
                 placeholder={t('taskItem.tagPlaceholder')}
                 list="existing-tags"

--- a/components/TaskItem/useTaskItem.ts
+++ b/components/TaskItem/useTaskItem.ts
@@ -27,25 +27,37 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
     } as const;
   }
 
+  const addTagFromValue = (value: string) => {
+    const newTag = value.trim();
+    if (newTag && !task.tags.includes(newTag)) {
+      const newTags = [...task.tags, newTag];
+      updateTask(task.id, { tags: newTags });
+      if (!allTags.find(t => t.label === newTag)) {
+        const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
+        addTag({
+          id: crypto.randomUUID(),
+          label: newTag,
+          color,
+          favorite: false,
+        });
+      }
+      setShowTagInput(false);
+    }
+  };
+
   const handleTagInputChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
-      const newTag = e.currentTarget.value.trim();
-      if (newTag && !task.tags.includes(newTag)) {
-        const newTags = [...task.tags, newTag];
-        updateTask(task.id, { tags: newTags });
-        if (!allTags.find(t => t.label === newTag)) {
-          const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
-          addTag({
-            id: crypto.randomUUID(),
-            label: newTag,
-            color,
-            favorite: false,
-          });
-        }
-        setShowTagInput(false);
-      }
+      addTagFromValue(e.currentTarget.value);
       e.currentTarget.value = '';
+    }
+  };
+
+  const handleExistingTagSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (allTags.some(tag => tag.label === value)) {
+      addTagFromValue(value);
+      e.target.value = '';
     }
   };
 
@@ -95,6 +107,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
       setTitle,
       setIsEditing,
       handleTagInputChange,
+      handleExistingTagSelect,
       removeTag,
       getTagColor,
       startEditing,


### PR DESCRIPTION
## Summary
- add handler to insert existing tags immediately on selection
- wire tag inputs to new handler for AddTask and TaskItem

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68aab3c5de98832cb5ebaac2240b45f1