### PR TITLE
feat: widen language menu and highlight selection

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
                 {language.toUpperCase()}
               </button>
               {showLang && (
-                <div className="absolute right-0 mt-2 rounded bg-gray-100 shadow dark:bg-gray-800">
+                <div className="absolute right-0 mt-2 w-48 rounded bg-gray-100 shadow dark:bg-gray-800">
                   {(['en', 'es'] as Language[]).map(code => (
                     <button
                       key={code}
@@ -75,7 +75,11 @@ export default function Header() {
                         setLanguage(code);
                         setShowLang(false);
                       }}
-                      className="block w-full px-4 py-2 text-left hover:bg-gray-200 dark:hover:bg-gray-700"
+                      className={`block w-full px-4 py-2 text-left hover:bg-gray-200 dark:hover:bg-gray-700 ${
+                        code === language
+                          ? 'bg-gray-200 dark:bg-gray-700 font-semibold'
+                          : ''
+                      }`}
                     >
                       {code.toUpperCase()} - {t(`lang.${code}`)}
                     </button>


### PR DESCRIPTION
## Summary
- allow header language dropdown to be wider
- highlight currently selected language in the menu

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac0a5fbb64832cbc974f16f7d1bfcf