### PR TITLE
Add notifications screen with initial welcome message

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import NotificationCard from '../../components/NotificationCard/NotificationCard';
+import { useStore } from '../../lib/store';
+import { useI18n } from '../../lib/i18n';
+
+export default function NotificationsPage() {
+  const notifications = useStore(state => state.notifications);
+  const markAllNotificationsRead = useStore(
+    state => state.markAllNotificationsRead
+  );
+  const { t } = useI18n();
+
+  useEffect(() => {
+    markAllNotificationsRead();
+  }, [markAllNotificationsRead]);
+
+  const sorted = [...notifications].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-4 p-4">
+      <h1 className="text-2xl font-bold">{t('notifications.title')}</h1>
+      {sorted.length === 0 ? (
+        <p>{t('notifications.empty')}</p>
+      ) : (
+        <div className="space-y-4">
+          {sorted.map(n => (
+            <NotificationCard
+              key={n.id}
+              notification={n}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,14 +1,30 @@
 'use client';
 import Link from 'next/link';
 import { useState } from 'react';
-import { Download, Upload, Trash2, Sun, Moon, Settings } from 'lucide-react';
+import {
+  Download,
+  Upload,
+  Trash2,
+  Sun,
+  Moon,
+  Settings,
+  Bell,
+} from 'lucide-react';
 import { Language, LANGUAGES } from '../../lib/i18n';
 import Icon from '../Icon/Icon';
 import useHeader from './useHeader';
 
 export default function Header() {
   const { state, actions } = useHeader();
-  const { showConfirm, showLang, theme, t, language, myDayCount } = state;
+  const {
+    showConfirm,
+    showLang,
+    theme,
+    t,
+    language,
+    myDayCount,
+    unreadNotifications,
+  } = state;
   const {
     exportData,
     setShowConfirm,
@@ -88,6 +104,19 @@ export default function Header() {
               )}
             </div>
           </div>
+          <Link
+            href="/notifications"
+            aria-label={t('actions.notifications')}
+            title={t('actions.notifications')}
+            className="relative rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+          >
+            <Bell className="h-4 w-4" />
+            {unreadNotifications > 0 && (
+              <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
+                {unreadNotifications}
+              </span>
+            )}
+          </Link>
           <button
             onClick={() => setShowActions(true)}
             aria-label={t('actions.settings')}

--- a/components/Header/useHeader.ts
+++ b/components/Header/useHeader.ts
@@ -4,17 +4,21 @@ import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
 
 export default function useHeader() {
-  const { tasks, exportData, importData, clearAll } = useStore(state => ({
-    tasks: state.tasks,
-    exportData: state.exportData,
-    importData: state.importData,
-    clearAll: state.clearAll,
-  }));
+  const { tasks, exportData, importData, clearAll, notifications } = useStore(
+    state => ({
+      tasks: state.tasks,
+      exportData: state.exportData,
+      importData: state.importData,
+      clearAll: state.clearAll,
+      notifications: state.notifications,
+    })
+  );
   const { t, language, setLanguage } = useI18n();
   const [showConfirm, setShowConfirm] = useState(false);
   const [showLang, setShowLang] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>('dark');
   const myDayCount = tasks.filter(t => t.plannedFor !== null).length;
+  const unreadNotifications = notifications.filter(n => !n.read).length;
 
   useEffect(() => {
     const stored = localStorage.getItem('theme');
@@ -54,7 +58,15 @@ export default function useHeader() {
   };
 
   return {
-    state: { showConfirm, showLang, theme, t, language, myDayCount },
+    state: {
+      showConfirm,
+      showLang,
+      theme,
+      t,
+      language,
+      myDayCount,
+      unreadNotifications,
+    },
     actions: {
       exportData,
       setShowConfirm,

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Info, AlertTriangle, Lightbulb } from 'lucide-react';
+import { useI18n } from '../../lib/i18n';
+import { Notification } from '../../lib/types';
+
+interface Props {
+  notification: Notification;
+}
+
+export default function NotificationCard({ notification }: Props) {
+  const { t } = useI18n();
+  const Icon =
+    notification.type === 'alert'
+      ? AlertTriangle
+      : notification.type === 'tip'
+        ? Lightbulb
+        : Info;
+
+  return (
+    <div className="rounded border border-gray-200 p-4 dark:border-gray-700">
+      <div className="flex items-start gap-3">
+        <Icon className="mt-1 h-5 w-5 flex-shrink-0" />
+        <div className="flex-1">
+          <h2 className="font-semibold">{t(notification.titleKey)}</h2>
+          <p className="text-sm">{t(notification.descriptionKey)}</p>
+          {notification.actionUrl && notification.actionLabelKey && (
+            <a
+              href={notification.actionUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-block rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-500"
+            >
+              {t(notification.actionLabelKey)}
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -18,18 +18,18 @@ export default function NotificationCard({ notification }: Props) {
         : Info;
 
   return (
-    <div className="rounded border border-gray-200 p-4 dark:border-gray-700">
-      <div className="flex items-start gap-3">
-        <Icon className="mt-1 h-5 w-5 flex-shrink-0" />
+    <div className="rounded border border-gray-200 p-6 dark:border-gray-700">
+      <div className="flex items-start gap-4">
+        <Icon className="mt-1 h-6 w-6 flex-shrink-0" />
         <div className="flex-1">
-          <h2 className="font-semibold">{t(notification.titleKey)}</h2>
-          <p className="text-sm">{t(notification.descriptionKey)}</p>
+          <h2 className="text-lg font-semibold">{t(notification.titleKey)}</h2>
+          <p className="text-base mt-1 w-full">{t(notification.descriptionKey)}</p>
           {notification.actionUrl && notification.actionLabelKey && (
             <a
               href={notification.actionUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-2 inline-block rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-500"
+              className="mt-3 inline-block rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-500"
             >
               {t(notification.actionLabelKey)}
             </a>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -299,7 +299,7 @@ const translations: Record<Language, any> = {
       title: 'Notificaciones',
       empty: 'Sin notificaciones',
       welcome: {
-        title: 'Bienvenido a Local Quick Planner',
+        title: '¡Hola! Te damos la bienvenida a Local Quick Planner',
         description:
           'Usa el tablero "Mis Tareas" para reunir y priorizar todo lo que debes hacer. Pasa los elementos a "Mi Día" cuando quieras enfocarte en ellos. Abre los ajustes para cambiar el tema, exportar tus datos y más.',
       },

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -27,6 +27,7 @@ const translations: Record<Language, any> = {
       favoriteTag: 'Add tag to favorites',
       unfavoriteTag: 'Remove tag from favorites',
       close: 'Close',
+      notifications: 'Notifications',
     },
     confirmDelete: {
       message:
@@ -83,6 +84,15 @@ const translations: Record<Language, any> = {
       p4: 'Designed for personal use, not for teams.',
       p5: '100% free and unlimited, open source.',
       cta: "Let's go!",
+    },
+    notifications: {
+      title: 'Notifications',
+      empty: 'No notifications',
+      welcome: {
+        title: 'Welcome to Local Quick Planner',
+        description:
+          'Use the "My Tasks" board to collect and prioritize everything you need to do. Move items into "My Day" when you are ready to focus on them. Open settings to switch theme, export your data and more.',
+      },
     },
     footer: {
       about: 'About',
@@ -227,6 +237,7 @@ const translations: Record<Language, any> = {
       favoriteTag: 'Marcar etiqueta como favorita',
       unfavoriteTag: 'Quitar etiqueta de favoritas',
       close: 'Cerrar',
+      notifications: 'Notificaciones',
     },
     confirmDelete: {
       message:
@@ -283,6 +294,15 @@ const translations: Record<Language, any> = {
       p4: 'Diseñado para uso personal, no para equipos.',
       p5: '100% gratis e ilimitado, open source.',
       cta: '¡Vamos!',
+    },
+    notifications: {
+      title: 'Notificaciones',
+      empty: 'Sin notificaciones',
+      welcome: {
+        title: 'Bienvenido a Local Quick Planner',
+        description:
+          'Usa el tablero "Mis Tareas" para reunir y priorizar todo lo que debes hacer. Pasa los elementos a "Mi Día" cuando quieras enfocarte en ellos. Abre los ajustes para cambiar el tema, exportar tus datos y más.',
+      },
     },
     footer: {
       about: 'Acerca de',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,5 +27,17 @@ export type PersistedState = {
   lists: List[];
   tags: Tag[];
   order: Record<string, string[]>;
+  notifications: Notification[];
   version: number;
+};
+
+export type Notification = {
+  id: string;
+  type: 'info' | 'tip' | 'alert';
+  titleKey: string;
+  descriptionKey: string;
+  read: boolean;
+  createdAt: string;
+  actionUrl?: string;
+  actionLabelKey?: string;
 };


### PR DESCRIPTION
## Summary
- add notification bell with unread badge and navigation to notifications
- introduce notifications store and types with initial welcome message
- create notifications page and card with i18n text

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad547c3730832c8cdf1e2af7a0319a