### PR TITLE
Linkify URLs in task titles

### DIFF
--- a/components/LinkifiedText/LinkifiedText.tsx
+++ b/components/LinkifiedText/LinkifiedText.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface LinkifiedTextProps {
+  text: string;
+}
+
+export default function LinkifiedText({ text }: LinkifiedTextProps) {
+  const parts = text.split(/(https?:\/\/[^\s]+)/g);
+  return (
+    <>
+      {parts.map((part, index) =>
+        /^https?:\/\//.test(part) ? (
+          <a
+            key={index}
+            href={part}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline text-blue-600 dark:text-blue-400"
+            onClick={e => e.stopPropagation()}
+          >
+            {part}
+          </a>
+        ) : (
+          part
+        )
+      )}
+    </>
+  );
+}

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -2,6 +2,7 @@
 import { Check, Trash2, Play } from 'lucide-react';
 import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
+import LinkifiedText from '../LinkifiedText/LinkifiedText';
 
 const priorityColors = {
   low: 'border-l-green-500',
@@ -28,7 +29,9 @@ export default function TaskCard(props: UseTaskCardProps) {
           mode === 'my-day' ? 'items-start' : 'items-center'
         }`}
       >
-        <span className="flex-1 mr-2">{task.title}</span>
+        <span className="flex-1 mr-2">
+          <LinkifiedText text={task.title} />
+        </span>
         <div
           className={`flex gap-2 ${
             mode === 'my-day' ? 'items-start' : 'items-center'

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -12,6 +12,7 @@ import { useI18n } from '../../lib/i18n';
 import useTaskItem, { UseTaskItemProps } from './useTaskItem';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import LinkifiedText from '../LinkifiedText/LinkifiedText';
 
 interface TaskItemProps extends UseTaskItemProps {
   highlighted?: boolean;
@@ -143,7 +144,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
               className="w-full md:flex-1"
               onClick={startEditing}
             >
-              {task.title}
+              <LinkifiedText text={task.title} />
             </p>
           )}
           <div className="hidden md:flex items-center gap-2">

--- a/tests/LinkifiedText.test.tsx
+++ b/tests/LinkifiedText.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import LinkifiedText from '../components/LinkifiedText/LinkifiedText';
+
+describe('LinkifiedText', () => {
+  it('renders links that open in a new tab', () => {
+    render(<LinkifiedText text="Revisar PR https://example.com" />);
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+});


### PR DESCRIPTION
## Summary
- render URLs as clickable links that open in a new tab
- support linkified titles in both My Day and My Tasks views
- test linkifying behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f30c7fc832c9c5c18d930461c61