### PR TITLE
Improve empty task list with animated illustration

### DIFF
--- a/components/TaskList/NoTasksIllustration.tsx
+++ b/components/TaskList/NoTasksIllustration.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { SVGProps } from 'react';
+
+export default function NoTasksIllustration(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect
+        x="12"
+        y="8"
+        width="40"
+        height="48"
+        rx="4"
+        ry="4"
+      />
+      <path d="M24 16h16" />
+      <path d="M20 24h24" />
+      <path d="M20 32h24" />
+      <path d="M20 40h24" />
+      <polyline
+        points="20 48 28 56 44 40"
+        strokeDasharray="80"
+        strokeDashoffset="80"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          from="80"
+          to="0"
+          dur="1.5s"
+          fill="freeze"
+          begin="0s"
+          repeatCount="indefinite"
+        />
+      </polyline>
+    </svg>
+  );
+}

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -7,6 +7,7 @@ import {
 import TaskItem from '../TaskItem/TaskItem';
 import { useI18n } from '../../lib/i18n';
 import useTaskList, { UseTaskListProps } from './useTaskList';
+import NoTasksIllustration from './NoTasksIllustration';
 
 interface TaskListProps extends UseTaskListProps {
   highlightedId?: string | null;
@@ -35,9 +36,12 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
             />
           ))}
           {tasks.length === 0 && (
-            <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-              {t('taskList.noTasks')}
-            </p>
+            <div className="flex flex-col items-center">
+              <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+                {t('taskList.noTasks')}
+              </p>
+              <NoTasksIllustration className="mt-4 h-32 w-32 text-gray-400 dark:text-gray-500" />
+            </div>
           )}
         </div>
       </SortableContext>


### PR DESCRIPTION
## Summary
- add animated SVG illustration for empty task lists
- display illustration below "no hay tareas" message with theme-aware colors

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae99a2630c832c9dc9fbad942ba74b