### PR TITLE
Show empty My Day state with link to My Tasks

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -1,10 +1,37 @@
 'use client';
+import Link from 'next/link';
 import Board from '../../components/Board/Board';
+import { useStore } from '../../lib/store';
+import { useI18n } from '../../lib/i18n';
 
 export default function MyDayPage() {
+  const { t } = useI18n();
+  const tasks = useStore(state => state.tasks);
+  const hasMyDayTasks = tasks.some(task => task.plannedFor !== null);
+
   return (
-    <main>
-      <Board mode="my-day" />
+    <main
+      className={
+        hasMyDayTasks
+          ? undefined
+          : 'flex flex-col items-center justify-center p-4 text-center'
+      }
+    >
+      {hasMyDayTasks ? (
+        <Board mode="my-day" />
+      ) : (
+        <>
+          <p className="mb-4 text-lg text-gray-600 dark:text-gray-300">
+            {t('myDayPage.empty')}
+          </p>
+          <Link
+            href="/my-tasks"
+            className="rounded bg-[#57886C] px-4 py-2 text-white hover:brightness-110 focus:ring"
+          >
+            {t('myDayPage.goToMyTasks')}
+          </Link>
+        </>
+      )}
     </main>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -64,6 +64,10 @@ const translations: Record<Language, any> = {
       deleteTask: 'Delete task',
       tagPlaceholder: 'Add tag',
     },
+    myDayPage: {
+      empty: 'No tasks added to My Day',
+      goToMyTasks: 'Go to My Tasks',
+    },
     timer: {
       start: 'Start timer',
       pause: 'Pause timer',
@@ -273,6 +277,10 @@ const translations: Record<Language, any> = {
       addMyDay: 'Agregar a Mi Día',
       deleteTask: 'Eliminar tarea',
       tagPlaceholder: 'Añadir etiqueta',
+    },
+    myDayPage: {
+      empty: 'No hay tareas añadidas a Mi Día',
+      goToMyTasks: 'Ir a Mis Tareas',
     },
     timer: {
       start: 'Iniciar temporizador',


### PR DESCRIPTION
## Summary
- display a centered message when My Day has no tasks
- link to My Tasks so users can add new tasks
- provide translations for the new empty-state in English and Spanish

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af2c0ac088832c9f6c2fe0c8c6c551