### PR TITLE
feat: enable offline-first PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Your privacy is paramount: all data is stored locally in your browser's `localSt
 
 Then open http://localhost:3000 in your browser.
 
+## 📱 PWA Icons
+
+Binary icons are omitted from the repository. Create the following PNG files in the `public/` directory before building to enable proper installation and splash screens:
+
+- `icon-192.png` — 192×192, maskable
+- `icon-512.png` — 512×512, maskable
+
+The 192px icon also serves as the Apple touch icon. Both files are referenced by `public/manifest.webmanifest` and `app/layout.tsx`.
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,30 @@
 import './globals.css';
 import type { ReactNode } from 'react';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Toaster } from 'react-hot-toast';
 import Header from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
 import { I18nProvider } from '../lib/i18n';
 import WelcomeModal from '../components/WelcomeModal/WelcomeModal';
+import ServiceWorker from '../components/ServiceWorker';
 
 export const metadata: Metadata = {
   title: 'Local Quick Planner',
+  manifest: '/manifest.webmanifest',
+  icons: {
+    icon: [
+      { url: '/icon-192.png', sizes: '192x192', type: 'image/png' },
+      { url: '/icon-512.png', sizes: '512x512', type: 'image/png' },
+    ],
+    apple: [{ url: '/icon-192.png', sizes: '192x192', type: 'image/png' }],
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#111827' },
+  ],
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -21,6 +37,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <Footer />
           <Toaster />
           <WelcomeModal />
+          <ServiceWorker />
         </I18nProvider>
       </body>
     </html>

--- a/components/ServiceWorker.tsx
+++ b/components/ServiceWorker.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ServiceWorker() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch(err => console.error('Service worker registration failed', err));
+    }
+  }, []);
+  return null;
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Local Quick Planner",
+  "short_name": "Quick Planner",
+  "description": "Plan your tasks and day locally.",
+  "start_url": "/my-tasks",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Offline</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 2rem;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline</h1>
+    <p>The application is not connected to the internet.</p>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = 'lqp-cache-v1';
+const APP_SHELL = ['/', '/my-tasks', '/my-day', '/offline.html'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then(cache => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(
+          keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        })
+        .catch(() =>
+          caches
+            .match(request)
+            .then(resp => resp || caches.match('/offline.html'))
+        )
+    );
+    return;
+  }
+
+  if (['style', 'script', 'image', 'font'].includes(request.destination)) {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        const fetchPromise = fetch(request)
+          .then(response => {
+            caches
+              .open(CACHE_NAME)
+              .then(cache => cache.put(request, response.clone()));
+            return response;
+          })
+          .catch(() => cached);
+        return cached || fetchPromise;
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add manifest, theme metadata, and service worker registration to enable installation and offline use
- implement service worker with precaching, static asset caching, and offline fallback
- document required icon assets and remove binary icons from repository

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea48be8e0832c93596c48757d97d5