### PR TITLE
Ensure tag colors are distinct and readable

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -24,6 +24,11 @@ export default function AddTask(props: UseAddTaskProps) {
   const titleRef = useRef(title);
   const initialTitleRef = useRef('');
 
+  const getTagColor = (tagLabel: string) => {
+    const tag = existingTags.find(t => t.label === tagLabel);
+    return tag ? tag.color : '#ccc';
+  };
+
   useEffect(() => {
     titleRef.current = title;
   }, [title]);
@@ -127,7 +132,8 @@ export default function AddTask(props: UseAddTaskProps) {
             {tags.map(tag => (
               <span
                 key={tag}
-                className="flex items-center rounded-full bg-gray-300 pl-2 pr-1 py-1 text-xs dark:bg-gray-700"
+                style={{ backgroundColor: getTagColor(tag) }}
+                className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs text-white"
               >
                 <span className="mr-1 select-none">{tag}</span>
                 <button

--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { Priority, Tag } from '../../lib/types';
+import { getNextTagColor } from '../../lib/tagColors';
 
 export interface UseAddTaskProps {
   addTask: (input: {
@@ -49,7 +50,7 @@ export default function useAddTask({
     if (newTag && !tags.includes(newTag)) {
       setTags([...tags, newTag]);
       if (!existingTags.find(t => t.label === newTag)) {
-        const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
+        const color = getNextTagColor(existingTags.map(t => t.color));
         addTag({
           id: crypto.randomUUID(),
           label: newTag,

--- a/components/TagFilter/TagFilter.tsx
+++ b/components/TagFilter/TagFilter.tsx
@@ -38,8 +38,8 @@ export default function TagFilter({
             }}
             role="button"
             tabIndex={0}
-            style={{ backgroundColor: isActive ? tag.color : '#ccc' }}
-            className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs cursor-pointer"
+            style={{ backgroundColor: tag.color, opacity: isActive ? 1 : 0.5 }}
+            className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs cursor-pointer text-white"
           >
             <span className="mr-1 select-none">{tag.label}</span>
             <button

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -89,7 +89,7 @@ export default function TaskCard(props: UseTaskCardProps) {
           <span
             key={tag}
             style={{ backgroundColor: getTagColor(tag) }}
-            className="text-xs px-2 py-1 rounded-full"
+            className="text-xs px-2 py-1 rounded-full text-white"
           >
             {tag}
           </span>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -157,7 +157,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
               <span
                 key={tag}
                 style={{ backgroundColor: getTagColor(tag) }}
-                className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs"
+                className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs text-white"
               >
                 <span className="mr-1 select-none">{tag}</span>
                 <button

--- a/components/TaskItem/useTaskItem.ts
+++ b/components/TaskItem/useTaskItem.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useStore } from '../../lib/store';
+import { getNextTagColor } from '../../lib/tagColors';
 
 export interface UseTaskItemProps {
   taskId: string;
@@ -33,7 +34,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
       const newTags = [...task.tags, newTag];
       updateTask(task.id, { tags: newTags });
       if (!allTags.find(t => t.label === newTag)) {
-        const color = `hsl(${Math.random() * 360}, 70%, 50%)`;
+        const color = getNextTagColor(allTags.map(t => t.color));
         addTag({
           id: crypto.randomUUID(),
           label: newTag,

--- a/lib/tagColors.ts
+++ b/lib/tagColors.ts
@@ -1,0 +1,16 @@
+export const TAG_COLORS = [
+  '#F44336', // red
+  '#FF9800', // orange
+  '#4CAF50', // green
+  '#2196F3', // blue
+  '#9C27B0', // purple
+  '#009688', // teal
+  '#E91E63', // pink
+  '#3F51B5', // indigo
+  '#00BCD4', // cyan
+];
+
+export function getNextTagColor(usedColors: string[]): string {
+  const available = TAG_COLORS.find(color => !usedColors.includes(color));
+  return available ?? TAG_COLORS[Math.floor(Math.random() * TAG_COLORS.length)];
+}


### PR DESCRIPTION
## Summary
- Introduce fixed palette and helper to choose distinct tag colors
- Render tags with white text so colors work in dark or light mode

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b47db5e948832c9320e987680e4374