### PR TITLE
Fix overflow for long task links

### DIFF
--- a/components/LinkifiedText/LinkifiedText.tsx
+++ b/components/LinkifiedText/LinkifiedText.tsx
@@ -15,7 +15,7 @@ export default function LinkifiedText({ text }: LinkifiedTextProps) {
             href={part}
             target="_blank"
             rel="noreferrer noopener"
-            className="underline text-blue-600 dark:text-blue-400"
+            className="underline text-blue-600 dark:text-blue-400 block max-w-full overflow-x-auto whitespace-nowrap"
             onClick={e => e.stopPropagation()}
           >
             {part}

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -29,7 +29,7 @@ export default function TaskCard(props: UseTaskCardProps) {
           mode === 'my-day' ? 'items-start' : 'items-center'
         }`}
       >
-        <span className="flex-1 mr-2">
+        <span className="flex-1 mr-2 min-w-0">
           <LinkifiedText text={task.title} />
         </span>
         <div

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -141,7 +141,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
             />
           ) : (
             <p
-              className="w-full md:flex-1"
+              className="w-full md:flex-1 min-w-0"
               onClick={startEditing}
             >
               <LinkifiedText text={task.title} />


### PR DESCRIPTION
## Summary
- prevent long links in tasks from breaking layout by constraining width and allowing horizontal scroll
- ensure task cards and items can shrink within flex layouts

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b67a9d00a0832cafa995f8ff3aa163