### PR TITLE
Hide task timer behind clock toggle

### DIFF
--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+import { type LucideIcon } from 'lucide-react';
+
+interface LinkProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: LucideIcon;
+  children: ReactNode;
+}
+
+export default function Link({
+  icon: Icon,
+  children,
+  className = '',
+  ...props
+}: LinkProps) {
+  return (
+    <button
+      type="button"
+      {...props}
+      className={`inline-flex items-center gap-1 rounded px-1 text-black dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer ${className}`}
+    >
+      {children}
+      {Icon && <Icon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { Check, Trash2, Play, Clock } from 'lucide-react';
+import Link from '../Link/Link';
 import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
@@ -97,20 +98,20 @@ export default function TaskCard(props: UseTaskCardProps) {
           </span>
         ))}
       </div>
-      {mode === 'my-day' &&
-        task.dayStatus === 'doing' &&
-        (showTimer ? (
-          <Timer taskTitle={task.title} />
-        ) : (
-          <button
-            onClick={() => setShowTimer(true)}
+      {mode === 'my-day' && task.dayStatus === 'doing' && (
+        <>
+          <Link
+            onClick={() => setShowTimer(s => !s)}
             aria-label={t('taskCard.showTimer')}
             title={t('taskCard.showTimer')}
-            className="mt-2 flex items-center text-blue-500 hover:underline"
+            icon={Clock}
+            className="mt-2"
           >
-            <Clock className="h-4 w-4" />
-          </button>
-        ))}
+            {t('taskCard.showTimer')}
+          </Link>
+          {showTimer && <Timer taskTitle={task.title} />}
+        </>
+      )}
     </div>
   );
 }

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { Check, Trash2, Play } from 'lucide-react';
+import { useState } from 'react';
+import { Check, Trash2, Play, Clock } from 'lucide-react';
 import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
@@ -15,6 +16,7 @@ export default function TaskCard(props: UseTaskCardProps) {
   const { attributes, listeners, setNodeRef, style, t } = state;
   const { markInProgress, markDone, getTagColor, deleteTask } = actions;
   const { task, mode } = props;
+  const [showTimer, setShowTimer] = useState(false);
 
   return (
     <div
@@ -95,9 +97,20 @@ export default function TaskCard(props: UseTaskCardProps) {
           </span>
         ))}
       </div>
-      {mode === 'my-day' && task.dayStatus === 'doing' && (
-        <Timer taskTitle={task.title} />
-      )}
+      {mode === 'my-day' &&
+        task.dayStatus === 'doing' &&
+        (showTimer ? (
+          <Timer taskTitle={task.title} />
+        ) : (
+          <button
+            onClick={() => setShowTimer(true)}
+            aria-label={t('taskCard.showTimer')}
+            title={t('taskCard.showTimer')}
+            className="mt-2 flex items-center text-blue-500 hover:underline"
+          >
+            <Clock className="h-4 w-4" />
+          </button>
+        ))}
     </div>
   );
 }

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -87,7 +87,7 @@ export default function TaskCard(props: UseTaskCardProps) {
           )}
         </div>
       </div>
-      <div className="mt-2 flex flex-wrap gap-1">
+      <div className="mt-4 flex flex-wrap gap-1">
         {task.tags?.map(tag => (
           <span
             key={tag}
@@ -105,7 +105,7 @@ export default function TaskCard(props: UseTaskCardProps) {
             aria-label={t('taskCard.showTimer')}
             title={t('taskCard.showTimer')}
             icon={Clock}
-            className="mt-2"
+            className="mt-4"
           >
             {t('taskCard.showTimer')}
           </Link>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -57,6 +57,7 @@ const translations: Record<Language, any> = {
       markInProgress: 'Move to In Progress',
       markDone: 'Mark as done',
       deleteTask: 'Delete task',
+      showTimer: 'Plan time',
     },
     taskItem: {
       removeMyDay: 'Remove from My Day',
@@ -271,6 +272,7 @@ const translations: Record<Language, any> = {
       markInProgress: 'Mover a En progreso',
       markDone: 'Marcar como completada',
       deleteTask: 'Eliminar tarea',
+      showTimer: 'Planificar tiempo',
     },
     taskItem: {
       removeMyDay: 'Quitar de Mi Día',


### PR DESCRIPTION
## Summary
- hide task timer until a clock icon is clicked
- add i18n strings for timer toggle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6859a39b8832ca071870e0195870f