### PR TITLE
Show add-tag link for tagless tasks

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -208,7 +208,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
               aria-label={t('actions.addTag')}
               title={t('actions.addTag')}
               icon={Plus}
-              className="text-white"
+              className="text-xs text-white"
             >
               {t('actions.addTag')}
             </Link>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -152,26 +152,26 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
             <Actions />
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="flex flex-wrap gap-1 items-center">
-            {task.tags.map((tag: string) => (
-              <span
-                key={tag}
-                style={{ backgroundColor: getTagColor(tag) }}
-                className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs text-white"
-              >
-                <span className="mr-1 select-none">{tag}</span>
-                <button
-                  onClick={() => removeTag(tag)}
-                  aria-label={t('actions.removeTag')}
-                  title={t('actions.removeTag')}
-                  className="ml-1 flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/20"
+        <div className="flex items-center gap-2 mt-2">
+          {task.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 items-center">
+              {task.tags.map((tag: string) => (
+                <span
+                  key={tag}
+                  style={{ backgroundColor: getTagColor(tag) }}
+                  className="flex items-center rounded-full pl-2 pr-1 py-1 text-xs text-white"
                 >
-                  ×
-                </button>
-              </span>
-            ))}
-            {task.tags.length > 0 && (
+                  <span className="mr-1 select-none">{tag}</span>
+                  <button
+                    onClick={() => removeTag(tag)}
+                    aria-label={t('actions.removeTag')}
+                    title={t('actions.removeTag')}
+                    className="ml-1 flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/20"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
               <button
                 onClick={toggleTagInput}
                 aria-label={t('actions.addTag')}
@@ -180,8 +180,8 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
               >
                 <Plus className="h-4 w-4" />
               </button>
-            )}
-          </div>
+            </div>
+          )}
           {showTagInput && (
             <>
               <input

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -13,6 +13,7 @@ import useTaskItem, { UseTaskItemProps } from './useTaskItem';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
+import Link from '../Link/Link';
 
 interface TaskItemProps extends UseTaskItemProps {
   highlighted?: boolean;
@@ -202,15 +203,15 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
             </>
           )}
           {!showTagInput && task.tags.length === 0 && (
-            <button
+            <Link
               onClick={toggleTagInput}
               aria-label={t('actions.addTag')}
               title={t('actions.addTag')}
-              className="flex items-center gap-1 text-sm text-blue-600 hover:underline dark:text-blue-400"
+              icon={Plus}
+              className="text-white"
             >
               {t('actions.addTag')}
-              <Plus className="h-4 w-4" />
-            </button>
+            </Link>
           )}
         </div>
         <div className="flex items-center gap-2 md:hidden">

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -181,7 +181,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
               </button>
             )}
           </div>
-          {(showTagInput || task.tags.length === 0) && (
+          {showTagInput && (
             <>
               <input
                 onKeyDown={handleTagInputChange}
@@ -200,6 +200,17 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
                 ))}
               </datalist>
             </>
+          )}
+          {!showTagInput && task.tags.length === 0 && (
+            <button
+              onClick={toggleTagInput}
+              aria-label={t('actions.addTag')}
+              title={t('actions.addTag')}
+              className="flex items-center gap-1 text-sm text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {t('actions.addTag')}
+              <Plus className="h-4 w-4" />
+            </button>
           )}
         </div>
         <div className="flex items-center gap-2 md:hidden">

--- a/components/TaskItem/useTaskItem.ts
+++ b/components/TaskItem/useTaskItem.ts
@@ -19,7 +19,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
   const task = tasks.find(t => t.id === taskId);
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(task?.title ?? '');
-  const [showTagInput, setShowTagInput] = useState(task?.tags.length === 0);
+  const [showTagInput, setShowTagInput] = useState(false);
 
   if (!task) {
     return {
@@ -66,7 +66,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
     const newTags = task.tags.filter(tag => tag !== tagToRemove);
     updateTask(task.id, { tags: newTags });
     if (newTags.length === 0) {
-      setShowTagInput(true);
+      setShowTagInput(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- Display an "Añadir etiqueta" link instead of tag input when a task has no tags
- Toggle tag input visibility from link and remove it when last tag is deleted

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b91c56c7e4832c9e4fbd83d117b033