### PR TITLE
Add motivational progress bar to My Day

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -1,13 +1,19 @@
 'use client';
 import Link from 'next/link';
 import Board from '../../components/Board/Board';
+import ProgressBar from '../../components/ProgressBar/ProgressBar';
 import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
 
 export default function MyDayPage() {
   const { t } = useI18n();
   const tasks = useStore(state => state.tasks);
-  const hasMyDayTasks = tasks.some(task => task.plannedFor !== null);
+  const plannedTasks = tasks.filter(task => task.plannedFor !== null);
+  const remainingTasks = plannedTasks.filter(task => task.dayStatus !== 'done');
+  const remainingPercent = plannedTasks.length
+    ? Math.round((remainingTasks.length / plannedTasks.length) * 100)
+    : 0;
+  const hasMyDayTasks = plannedTasks.length > 0;
 
   return (
     <main
@@ -18,7 +24,10 @@ export default function MyDayPage() {
       }
     >
       {hasMyDayTasks ? (
-        <Board mode="my-day" />
+        <>
+          <ProgressBar percent={remainingPercent} />
+          <Board mode="my-day" />
+        </>
       ) : (
         <>
           <p className="mb-4 text-lg text-gray-600 dark:text-gray-300">

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -23,14 +23,14 @@ export default function ProgressBar({ percent }: ProgressBarProps) {
   }
 
   return (
-    <div className="p-4">
-      <div className="h-2 w-full rounded bg-gray-200 dark:bg-gray-700">
+    <div className="p-4 opacity-30">
+      <div className="h-[3px] w-full rounded bg-gray-200 dark:bg-gray-700">
         <div
           className={`h-full rounded ${colorClass}`}
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="mt-2 text-center text-sm">{message}</p>
+      <p className="mt-4 text-center text-sm">{message}</p>
     </div>
   );
 }

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -23,14 +23,16 @@ export default function ProgressBar({ percent }: ProgressBarProps) {
   }
 
   return (
-    <div className="p-4 opacity-30">
-      <div className="h-[3px] w-full rounded bg-gray-200 dark:bg-gray-700">
+    <div className="p-4">
+      <div className="h-[3px] w-full rounded bg-gray-200 opacity-30 dark:bg-gray-700">
         <div
           className={`h-full rounded ${colorClass}`}
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="mt-4 text-center text-sm">{message}</p>
+      <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
+        {message}
+      </p>
     </div>
   );
 }

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useI18n } from '../../lib/i18n';
+
+interface ProgressBarProps {
+  percent: number;
+}
+
+export default function ProgressBar({ percent }: ProgressBarProps) {
+  const { t } = useI18n();
+
+  let colorClass = 'bg-green-500';
+  let message = t('myDayPage.progress.done');
+
+  if (percent > 0 && percent <= 33) {
+    message = t('myDayPage.progress.low');
+  } else if (percent > 33 && percent <= 66) {
+    colorClass = 'bg-yellow-500';
+    message = t('myDayPage.progress.medium');
+  } else if (percent > 66) {
+    colorClass = 'bg-red-500';
+    message = t('myDayPage.progress.full');
+  }
+
+  return (
+    <div className="p-4">
+      <div className="h-2 w-full rounded bg-gray-200 dark:bg-gray-700">
+        <div
+          className={`h-full rounded ${colorClass}`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="mt-2 text-center text-sm">{message}</p>
+    </div>
+  );
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -68,6 +68,12 @@ const translations: Record<Language, any> = {
     myDayPage: {
       empty: 'No tasks added to My Day',
       goToMyTasks: 'Go to My Tasks',
+      progress: {
+        full: "Big day ahead—let's get started!",
+        medium: "You're making progress—keep going!",
+        low: 'Almost there—keep it up!',
+        done: 'All tasks completed! Great job!',
+      },
     },
     timer: {
       start: 'Start timer',
@@ -283,6 +289,12 @@ const translations: Record<Language, any> = {
     myDayPage: {
       empty: 'No hay tareas añadidas a Mi Día',
       goToMyTasks: 'Ir a Mis Tareas',
+      progress: {
+        full: '¡Qué gran día, a por ello!',
+        medium: '¡Buen progreso, sigue así!',
+        low: '¡Ánimo, ya falta poco!',
+        done: '¡Todo hecho, gran trabajo!',
+      },
     },
     timer: {
       start: 'Iniciar temporizador',


### PR DESCRIPTION
## Summary
- add progress bar with color feedback and motivational text to My Day
- include translation strings for progress messages in English and Spanish

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba6db0db28832c8cbd6669e2e6e278