### PR TITLE
Update header icon for theme-aware logo

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="relative grid grid-cols-3 items-center bg-gray-100 px-4 py-3 dark:bg-gray-950 md:py-4 lg:py-5">
+      <header className="relative grid grid-cols-3 items-center bg-gray-100 px-4 py-2 dark:bg-gray-950 md:py-3 lg:py-4">
         <div className="flex items-center">
           <Icon />
         </div>

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -7,8 +7,8 @@ export default function Icon() {
       viewBox="0 0 80 80"
       role="img"
       aria-label="Local Quick Planner"
-      width="40"
-      height="40"
+      width="80"
+      height="80"
     >
       <rect
         x="15"
@@ -20,31 +20,31 @@ export default function Icon() {
       />
       <rect
         x="25"
-        y="25"
+        y="25.25"
         width="30"
-        height="5"
+        height="3"
         rx="2"
         className="fill-white dark:fill-gray-800"
       />
       <rect
         x="25"
-        y="35"
+        y="38.5"
         width="30"
-        height="5"
+        height="3"
         rx="2"
         className="fill-white dark:fill-gray-800"
       />
       <rect
         x="25"
-        y="45"
-        width="20"
-        height="5"
+        y="51.5"
+        width="12"
+        height="3"
         rx="2"
         className="fill-white dark:fill-gray-800"
       />
       <path
-        d="M45 50L49 54L57 46"
-        strokeWidth="4"
+        d="M44 53L47 56L54 49"
+        strokeWidth="3"
         strokeLinecap="round"
         strokeLinejoin="round"
         className="stroke-white dark:stroke-gray-800"

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -4,55 +4,52 @@ export default function Icon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 64 64"
+      viewBox="0 0 80 80"
       role="img"
       aria-label="Local Quick Planner"
       width="40"
       height="40"
     >
       <rect
-        width="56"
-        height="56"
-        x="4"
-        y="4"
+        x="15"
+        y="15"
+        width="50"
+        height="50"
         rx="10"
+        className="fill-black dark:fill-white"
+      />
+      <rect
+        x="25"
+        y="25"
+        width="30"
+        height="5"
+        rx="2"
         className="fill-white dark:fill-gray-800"
       />
       <rect
-        width="56"
-        height="56"
-        x="4"
-        y="4"
-        rx="10"
-        fill="none"
-        strokeWidth="2"
-        className="stroke-gray-200 dark:stroke-gray-700"
+        x="25"
+        y="35"
+        width="30"
+        height="5"
+        rx="2"
+        className="fill-white dark:fill-gray-800"
       />
-
-      <g transform="translate(14, 18)">
-        <rect
-          width="36"
-          height="4"
-          rx="2"
-          className="fill-gray-400 dark:fill-gray-400"
-        />
-        <rect
-          x="0"
-          y="12"
-          width="28"
-          height="4"
-          rx="2"
-          className="fill-gray-300 dark:fill-gray-500"
-        />
-        <rect
-          x="0"
-          y="24"
-          width="16"
-          height="4"
-          rx="2"
-          className="fill-gray-300 dark:fill-gray-500"
-        />
-      </g>
+      <rect
+        x="25"
+        y="45"
+        width="20"
+        height="5"
+        rx="2"
+        className="fill-white dark:fill-gray-800"
+      />
+      <path
+        d="M45 50L49 54L57 46"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-white dark:stroke-gray-800"
+        fill="none"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- replace header logo with new checklist-inspired SVG
- ensure icon colors swap for light and dark themes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc4ba6dd8832c9c96d90121812f7d