### PR TITLE
Reduce header padding and icon size on mobile

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="relative grid grid-cols-3 items-center bg-gray-100 px-4 py-2 dark:bg-gray-950 md:py-3 lg:py-4">
+      <header className="relative grid grid-cols-3 items-center bg-gray-100 px-2 py-2 dark:bg-gray-950 md:px-4 md:py-3 lg:py-4">
         <div className="flex items-center">
           <Icon />
         </div>

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -7,8 +7,7 @@ export default function Icon() {
       viewBox="0 0 80 80"
       role="img"
       aria-label="Local Quick Planner"
-      width="80"
-      height="80"
+      className="h-10 w-10 md:h-20 md:w-20"
     >
       <rect
         x="15"


### PR DESCRIPTION
## Summary
- shrink header horizontal padding on small screens
- add responsive sizing to app icon for smaller appearance on mobile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0f281ef4832c9ffd49839ab031b1