### PR TITLE
Fix My Day progress bar color transitions

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -10,8 +10,11 @@ export default function MyDayPage() {
   const tasks = useStore(state => state.tasks);
   const plannedTasks = tasks.filter(task => task.plannedFor !== null);
   const remainingTasks = plannedTasks.filter(task => task.dayStatus !== 'done');
-  const remainingPercent = plannedTasks.length
-    ? Math.round((remainingTasks.length / plannedTasks.length) * 100)
+  const progressPercent = plannedTasks.length
+    ? Math.round(
+        ((plannedTasks.length - remainingTasks.length) / plannedTasks.length) *
+          100
+      )
     : 0;
   const hasMyDayTasks = plannedTasks.length > 0;
 
@@ -25,7 +28,7 @@ export default function MyDayPage() {
     >
       {hasMyDayTasks ? (
         <>
-          <ProgressBar percent={remainingPercent} />
+          <ProgressBar percent={progressPercent} />
           <Board mode="my-day" />
         </>
       ) : (

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -9,17 +9,18 @@ interface ProgressBarProps {
 export default function ProgressBar({ percent }: ProgressBarProps) {
   const { t } = useI18n();
 
-  let colorClass = 'bg-green-500';
-  let message = t('myDayPage.progress.done');
+  let colorClass = 'bg-red-500';
+  let message = t('myDayPage.progress.full');
 
-  if (percent > 0 && percent <= 33) {
+  if (percent >= 100) {
+    colorClass = 'bg-green-500';
+    message = t('myDayPage.progress.done');
+  } else if (percent >= 67) {
+    colorClass = 'bg-green-500';
     message = t('myDayPage.progress.low');
-  } else if (percent > 33 && percent <= 66) {
+  } else if (percent >= 33) {
     colorClass = 'bg-yellow-500';
     message = t('myDayPage.progress.medium');
-  } else if (percent > 66) {
-    colorClass = 'bg-red-500';
-    message = t('myDayPage.progress.full');
   }
 
   return (


### PR DESCRIPTION
## Summary
- compute progress using completed tasks in My Day
- update progress bar to show red→yellow→green sequence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbc633a9e8832cb314888ac5c2562a