### PR TITLE
style: refine task link scrollbar on Windows

### DIFF
--- a/components/LinkifiedText/LinkifiedText.tsx
+++ b/components/LinkifiedText/LinkifiedText.tsx
@@ -15,7 +15,7 @@ export default function LinkifiedText({ text }: LinkifiedTextProps) {
             href={part}
             target="_blank"
             rel="noreferrer noopener"
-            className="underline text-blue-600 dark:text-blue-400 block max-w-full overflow-x-auto whitespace-nowrap"
+            className="underline text-blue-600 dark:text-blue-400 block max-w-full overflow-x-auto whitespace-nowrap [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-600"
             onClick={e => e.stopPropagation()}
           >
             {part}


### PR DESCRIPTION
## Summary
- make task link scrollbar thinner and subtler to mirror macOS

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0feeca18832c922f9c50c1c92bf5