### PR TITLE
Improve tag filter spacing and link in My Tasks view

### DIFF
--- a/components/TagFilter/TagFilter.tsx
+++ b/components/TagFilter/TagFilter.tsx
@@ -2,6 +2,7 @@
 import { Tag } from '../../lib/types';
 import { useI18n } from '../../lib/i18n';
 import { Star } from 'lucide-react';
+import Link from '../Link/Link';
 
 interface TagFilterProps {
   tags: Tag[];
@@ -23,7 +24,7 @@ export default function TagFilter({
   const { t } = useI18n();
   if (tags.length === 0) return null;
   return (
-    <div className="flex flex-wrap items-center gap-2 px-4 pb-2">
+    <div className="mt-4 flex flex-wrap items-center gap-2 px-4 pb-2">
       {tags.map(tag => {
         const isActive = activeTags.includes(tag.label);
         return (
@@ -78,12 +79,12 @@ export default function TagFilter({
           </div>
         );
       })}
-      <button
+      <Link
         onClick={showAll}
-        className="text-xs underline"
+        className="text-xs"
       >
         {t('tagFilter.showAll')}
-      </button>
+      </Link>
     </div>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -83,7 +83,7 @@ const translations: Record<Language, any> = {
     priority: { low: 'Low', medium: 'Medium', high: 'High' },
     taskList: { noTasks: 'No tasks' },
     tagFilter: {
-      showAll: 'Show all tasks',
+      showAll: 'Show all',
       confirmDelete:
         'Some tasks are using this tag. If you remove it, those tasks will lose the tag. Continue?',
     },
@@ -304,7 +304,7 @@ const translations: Record<Language, any> = {
     priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
     taskList: { noTasks: 'No hay tareas' },
     tagFilter: {
-      showAll: 'Mostrar todas las tareas',
+      showAll: 'Mostrar todas',
       confirmDelete:
         'Algunas tareas usan esta etiqueta. Si la eliminas, esas tareas perderán la etiqueta. ¿Continuar?',
     },


### PR DESCRIPTION
## Summary
- add extra spacing above tag filters in the My Tasks view
- replace "show all" button with new Link component and shorten text
- update translations for the new copy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd119494ac832c995006ad4978e9b0