### PR TITLE
Fix spacing when no tags in mobile task form

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -108,7 +108,11 @@ export default function AddTask(props: UseAddTaskProps) {
             <Mic className="h-4 w-4" />
           </button>
         </div>
-        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+        <div
+          className={`flex w-full flex-wrap items-center sm:w-auto${
+            tags.length ? ' gap-2' : ''
+          }`}
+        >
           <label
             htmlFor="task-tags"
             className="sr-only"


### PR DESCRIPTION
## Summary
- ensure consistent spacing between tag input and actions when no tags are present on mobile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd189005ac832cbddb6b1976201e04