### PR TITLE
feat: truncate long task links with ellipsis

### DIFF
--- a/components/LinkifiedText/LinkifiedText.tsx
+++ b/components/LinkifiedText/LinkifiedText.tsx
@@ -15,7 +15,8 @@ export default function LinkifiedText({ text }: LinkifiedTextProps) {
             href={part}
             target="_blank"
             rel="noreferrer noopener"
-            className="underline text-blue-600 dark:text-blue-400 block max-w-full overflow-x-auto whitespace-nowrap [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-600"
+            title={part}
+            className="underline text-blue-600 dark:text-blue-400 block max-w-full truncate"
             onClick={e => e.stopPropagation()}
           >
             {part}


### PR DESCRIPTION
## Summary
- shorten long task links with ellipsis while preserving full href and title tooltip

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c24ebf942c832cb5fb6874de821626