### PR TITLE
feat: add responsive logo text

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -41,8 +41,11 @@ export default function Header() {
   return (
     <>
       <header className="relative grid grid-cols-3 items-center bg-gray-100 px-2 py-2 dark:bg-gray-950 md:px-4 md:py-3 lg:py-4">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           <Icon />
+          <span className="hidden text-lg font-semibold text-black dark:text-white sm:inline">
+            Local Quick Planner
+          </span>
         </div>
         <nav className="flex h-full items-center justify-center gap-4">
           <Link


### PR DESCRIPTION
## Summary
- show "Local Quick Planner" text next to logo with theme-aware styling

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c253b95ae0832c86e6783ba2fd82af