### PR TITLE
Add left border styling for My Day tasks

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -124,10 +124,10 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
         <GripVertical className="h-4 w-4 text-gray-500" />
       </div>
       <div
-        className={`flex flex-col gap-2 rounded p-2 flex-1 min-w-0 ${
+        className={`flex flex-col gap-2 rounded p-2 flex-1 min-w-0 bg-gray-100 dark:bg-gray-800 ${
           task.plannedFor
-            ? 'bg-blue-100 dark:bg-[rgb(62,74,113)]'
-            : 'bg-gray-100 dark:bg-gray-800'
+            ? 'pl-4 md:pl-6 border-l-[8px] md:border-l-[16px] border-blue-100 dark:border-[rgb(62,74,113)]'
+            : ''
         } ${highlighted ? 'ring-2 ring-[#57886C] bg-[#57886C] text-white' : ''}`}
       >
         <div className="flex flex-col gap-2 md:flex-row md:items-center">

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -126,7 +126,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
       <div
         className={`flex flex-col gap-2 rounded p-2 flex-1 min-w-0 bg-gray-100 dark:bg-gray-800 ${
           task.plannedFor
-            ? 'pl-4 md:pl-6 border-l-[8px] md:border-l-[16px] border-blue-100 dark:border-[rgb(62,74,113)]'
+            ? 'pl-4 md:pl-5 border-l-[8px] md:border-l-[16px] border-blue-100 dark:border-[rgb(62,74,113)]'
             : ''
         } ${highlighted ? 'ring-2 ring-[#57886C] bg-[#57886C] text-white' : ''}`}
       >


### PR DESCRIPTION
## Summary
- replace My Day task background with subtle left border
- add responsive padding and border width for My Day items

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c78fc1f78c832c9e8426aa7c2ad167