### PR TITLE
Enable task list drag on mobile

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -120,6 +120,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
         {...attributes}
         {...listeners}
         className="flex items-center pr-2 cursor-grab"
+        style={{ touchAction: 'none' }}
       >
         <GripVertical className="h-4 w-4 text-gray-500" />
       </div>

--- a/components/TaskList/useTaskList.ts
+++ b/components/TaskList/useTaskList.ts
@@ -1,7 +1,8 @@
 'use client';
 import { useCallback } from 'react';
 import {
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   DragEndEvent,
@@ -15,7 +16,10 @@ export interface UseTaskListProps {
 
 export default function useTaskList({ tasks }: UseTaskListProps) {
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 100, tolerance: 5 },
+    })
   );
   const { reorderMyTasks } = useStore();
 


### PR DESCRIPTION
## Summary
- support touch dragging in task list via TouchSensor
- prevent default scrolling on drag handle to allow mobile reordering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd1b85dadc832cb987dcba89569994