### PR TITLE
Improve plan time timer layout

### DIFF
--- a/components/TaskCard/Timer.tsx
+++ b/components/TaskCard/Timer.tsx
@@ -70,22 +70,22 @@ export default function Timer({ taskTitle }: TimerProps) {
   const progress = duration > 0 ? ((duration - timeLeft) / duration) * 100 : 0;
 
   return (
-    <div className="mt-2 space-y-2">
-      <div className="flex items-center gap-2">
-        <select
-          value={duration}
-          onChange={handleDurationChange}
-          className="rounded bg-gray-200 p-1 text-sm dark:bg-gray-700"
-        >
-          {options.map(o => (
-            <option
-              key={o.value}
-              value={o.value}
-            >
-              {o.label}
-            </option>
-          ))}
-        </select>
+    <div className="mt-2 flex items-center gap-2">
+      <select
+        value={duration}
+        onChange={handleDurationChange}
+        className="rounded bg-gray-200 p-1 text-sm dark:bg-gray-700"
+      >
+        {options.map(o => (
+          <option
+            key={o.value}
+            value={o.value}
+          >
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <div className="flex items-center gap-1">
         <button
           onClick={toggle}
           aria-label={running ? t('timer.pause') : t('timer.start')}
@@ -103,7 +103,7 @@ export default function Timer({ taskTitle }: TimerProps) {
           {(timeLeft % 60).toString().padStart(2, '0')}
         </span>
       </div>
-      <div className="h-2 w-full rounded bg-gray-300 dark:bg-gray-700">
+      <div className="h-2 flex-1 rounded bg-gray-300 dark:bg-gray-700">
         <div
           className="h-2 rounded bg-blue-500 dark:bg-blue-400"
           style={{ width: `${progress}%` }}

--- a/components/TaskCard/__tests__/TaskCard.test.tsx
+++ b/components/TaskCard/__tests__/TaskCard.test.tsx
@@ -22,10 +22,10 @@ describe('TaskCard', () => {
   beforeEach(() => {
     mockUseTaskCard.mockReturnValue({
       state: {
-        attributes: {},
-        listeners: {},
+        attributes: {} as any,
+        listeners: {} as any,
         setNodeRef: jest.fn(),
-        style: {},
+        style: {} as any,
         t: (k: string) => k,
         allTags: [],
       },


### PR DESCRIPTION
## Summary
- streamline plan time timer to display controls, countdown and progress bar in a single row
- adjust TaskCard test types to satisfy type checking

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c79d60d988832c8c1179c207ddcf88