### PR TITLE
feat: add social metadata and previews

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,8 +8,12 @@ import { I18nProvider } from '../lib/i18n';
 import WelcomeModal from '../components/WelcomeModal/WelcomeModal';
 import ServiceWorker from '../components/ServiceWorker';
 
+const description =
+  'Local Quick Planner is a free, fast, private, and open source task manager that boosts your productivity and personal organization at work.';
+
 export const metadata: Metadata = {
   title: 'Local Quick Planner',
+  description,
   manifest: '/manifest.webmanifest',
   icons: {
     icon: [
@@ -17,6 +21,19 @@ export const metadata: Metadata = {
       { url: '/icon-512.png', sizes: '512x512', type: 'image/png' },
     ],
     apple: [{ url: '/icon-192.png', sizes: '192x192', type: 'image/png' }],
+  },
+  openGraph: {
+    title: 'Local Quick Planner',
+    description,
+    siteName: 'Local Quick Planner',
+    images: [
+      {
+        url: '/icon-512.png',
+        width: 512,
+        height: 512,
+        alt: 'Local Quick Planner logo',
+      },
+    ],
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,5 @@
-'use client';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { redirect } from 'next/navigation';
 
 export default function IndexPage() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace('/my-day');
-  }, [router]);
-  return null;
+  redirect('/my-day');
 }


### PR DESCRIPTION
## Summary
- add Open Graph metadata using existing 512px icon as social preview
- redirect root path on server and simplify pages to rely on global defaults
- remove social preview docs from README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c657594f8c832cb4bbd70bef3a5dd2