### PR TITLE
Maintain task timers across app navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import Footer from '../components/Footer/Footer';
 import { I18nProvider } from '../lib/i18n';
 import WelcomeModal from '../components/WelcomeModal/WelcomeModal';
 import ServiceWorker from '../components/ServiceWorker';
+import TaskTimerManager from '../components/TaskTimerManager/TaskTimerManager';
 
 const description =
   'Local Quick Planner is a free, fast, private, and open source task manager that boosts your productivity and personal organization at work.';
@@ -53,6 +54,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <main className="flex-1">{children}</main>
           <Footer />
           <Toaster />
+          <TaskTimerManager />
           <WelcomeModal />
           <ServiceWorker />
         </I18nProvider>

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -109,7 +109,7 @@ export default function TaskCard(props: UseTaskCardProps) {
           >
             {t('taskCard.showTimer')}
           </Link>
-          {showTimer && <Timer taskTitle={task.title} />}
+          {showTimer && <Timer taskId={task.id} />}
         </>
       )}
     </div>

--- a/components/TaskTimerManager/TaskTimerManager.tsx
+++ b/components/TaskTimerManager/TaskTimerManager.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+import { useI18n } from '../../lib/i18n';
+import { useStore } from '../../lib/store';
+
+function playSound() {
+  try {
+    const Ctx = window.AudioContext || (window as any).webkitAudioContext;
+    const ctx = new Ctx();
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(880, ctx.currentTime);
+    gain.gain.setValueAtTime(0.05, ctx.currentTime);
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+    oscillator.start();
+    oscillator.stop(ctx.currentTime + 0.5);
+  } catch (error) {
+    // ignore
+  }
+}
+
+export default function TaskTimerManager() {
+  const { t } = useI18n();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const state = useStore.getState();
+      const now = Date.now();
+
+      Object.entries(state.timers).forEach(([taskId, timer]) => {
+        if (!timer.running || !timer.endsAt) {
+          return;
+        }
+
+        const endsAt = new Date(timer.endsAt).getTime();
+        if (Number.isNaN(endsAt)) {
+          state.completeTimer(taskId);
+          return;
+        }
+
+        const remaining = Math.max(0, Math.ceil((endsAt - now) / 1000));
+
+        if (remaining <= 0) {
+          state.completeTimer(taskId);
+          const task = state.tasks.find(t => t.id === taskId);
+          toast(t('timer.finished').replace('{task}', task?.title ?? ''));
+          playSound();
+        } else if (remaining !== timer.remaining) {
+          state.updateTimerRemaining(taskId, remaining);
+        }
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [t]);
+
+  return null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,12 +22,20 @@ export type Task = {
 
 export type List = { id: string; title: string; order: number };
 
+export type TaskTimer = {
+  duration: number;
+  remaining: number;
+  running: boolean;
+  endsAt: string | null;
+};
+
 export type PersistedState = {
   tasks: Task[];
   lists: List[];
   tags: Tag[];
   order: Record<string, string[]>;
   notifications: Notification[];
+  timers: Record<string, TaskTimer>;
   version: number;
 };
 


### PR DESCRIPTION
## Summary
- persist timer data in the store, migrate saved state and expose actions to manage per-task timers
- update the task timer UI to consume the shared state so countdowns continue when switching views
- add a global timer manager that keeps timers running and fires notifications when a countdown finishes

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c8e7e67000832c96768b5f0548e6d8