### PR TITLE
Add configurable work schedule and reminders

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,7 +7,7 @@ export default function AboutPage() {
   const { t } = useI18n();
 
   return (
-    <main className="mx-auto max-w-2xl space-y-4 p-4">
+    <main className="mx-auto max-w-2xl space-y-4 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('aboutPage.title')}</h1>
       <p>{t('aboutPage.intro')}</p>
       <ul className="list-disc space-y-1 pl-6">

--- a/app/faqs/page.tsx
+++ b/app/faqs/page.tsx
@@ -19,7 +19,7 @@ export default function FAQsPage() {
   ];
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('faqs.title')}</h1>
       <Accordion items={faqs} />
       <div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from '../lib/i18n';
 import WelcomeModal from '../components/WelcomeModal/WelcomeModal';
 import ServiceWorker from '../components/ServiceWorker';
 import TaskTimerManager from '../components/TaskTimerManager/TaskTimerManager';
+import WorkScheduleManager from '../components/WorkScheduleManager/WorkScheduleManager';
 
 const description =
   'Local Quick Planner is a free, fast, private, and open source task manager that boosts your productivity and personal organization at work.';
@@ -55,6 +56,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <Footer />
           <Toaster />
           <TaskTimerManager />
+          <WorkScheduleManager />
           <WelcomeModal />
           <ServiceWorker />
         </I18nProvider>

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -21,7 +21,7 @@ export default function NotificationsPage() {
   );
 
   return (
-    <main className="mx-auto max-w-2xl space-y-4 p-4">
+    <main className="mx-auto max-w-2xl space-y-4 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('notifications.title')}</h1>
       {sorted.length === 0 ? (
         <p>{t('notifications.empty')}</p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export default function PrivacyPage() {
   const { t } = useI18n();
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('privacyPage.title')}</h1>
       <p>{t('privacyPage.intro')}</p>
       <h2 className="text-xl font-semibold">

--- a/app/settings/work-schedule/page.tsx
+++ b/app/settings/work-schedule/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent, PointerEvent } from 'react';
 import { toast } from 'react-hot-toast';
 import { useStore } from '../../../lib/store';
@@ -93,6 +93,7 @@ export default function WorkSchedulePage() {
     setPlanningReminderMinutes: state.setPlanningReminderMinutes,
   }));
   const [dragMode, setDragMode] = useState<DragMode | null>(null);
+  const calendarRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const handlePointerEnd = () => setDragMode(null);
@@ -102,6 +103,19 @@ export default function WorkSchedulePage() {
       window.removeEventListener('pointerup', handlePointerEnd);
       window.removeEventListener('pointercancel', handlePointerEnd);
     };
+  }, []);
+
+  useEffect(() => {
+    if (!calendarRef.current) {
+      return;
+    }
+    const targetSlot = 7 * 2;
+    const firstRow = calendarRef.current.querySelector('tbody tr');
+    if (!firstRow) {
+      return;
+    }
+    const rowHeight = firstRow.getBoundingClientRect().height;
+    calendarRef.current.scrollTop = targetSlot * rowHeight;
   }, []);
 
   const selectedSlots = useMemo(() => {
@@ -166,32 +180,32 @@ export default function WorkSchedulePage() {
   };
 
   return (
-    <main className="mx-auto max-w-6xl space-y-6 p-4">
+    <main className="mx-auto max-w-6xl space-y-8 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('workSchedulePage.title')}</h1>
-      <p>{t('workSchedulePage.intro')}</p>
-      <p className="text-sm text-gray-600 dark:text-gray-300">
-        {t('workSchedulePage.helper')}
-      </p>
+      <div className="space-y-3">
+        <p>{t('workSchedulePage.intro')}</p>
+        <p className="text-base font-medium">
+          {t('workSchedulePage.calendar.instructions')}
+        </p>
+      </div>
       <section className="space-y-4">
-        <div className="space-y-1">
-          <h2 className="text-xl font-semibold">
-            {t('workSchedulePage.calendar.title')}
-          </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-300">
-            {t('workSchedulePage.calendar.instructions')}
-          </p>
-        </div>
-        <div className="overflow-x-auto rounded border border-gray-200 dark:border-gray-700">
+        <h2 className="text-xl font-semibold">
+          {t('workSchedulePage.calendar.title')}
+        </h2>
+        <div
+          ref={calendarRef}
+          className="max-h-[520px] overflow-auto rounded border border-gray-200 dark:border-gray-700"
+        >
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr className="bg-gray-50 dark:bg-gray-800">
-                <th className="sticky left-0 top-0 z-10 border border-gray-200 px-2 py-2 text-left font-semibold dark:border-gray-700 dark:bg-gray-800">
+                <th className="sticky left-0 top-0 z-10 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold dark:border-gray-700 dark:bg-gray-800">
                   {t('workSchedulePage.calendar.timeLabel')}
                 </th>
                 {WEEK_DAYS.map(day => (
                   <th
                     key={day}
-                    className="min-w-[120px] border border-gray-200 px-2 py-2 text-left font-semibold capitalize dark:border-gray-700"
+                    className="sticky top-0 z-10 min-w-[120px] border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold capitalize dark:border-gray-700 dark:bg-gray-800"
                   >
                     {t(`workSchedulePage.week.${day}`)}
                   </th>

--- a/app/settings/work-schedule/page.tsx
+++ b/app/settings/work-schedule/page.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent, PointerEvent } from 'react';
+import { toast } from 'react-hot-toast';
+import { useStore } from '../../../lib/store';
+import { useI18n } from '../../../lib/i18n';
+import type { Weekday } from '../../../lib/types';
+
+type DragMode = 'add' | 'remove';
+
+const WEEK_DAYS: Weekday[] = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+];
+
+const SLOT_INDICES = Array.from({ length: 48 }, (_, index) => index);
+
+const MINUTE_OPTIONS = [5, 15, 30, 60];
+
+function formatSlotStart(slot: number) {
+  const hours = Math.floor(slot / 2)
+    .toString()
+    .padStart(2, '0');
+  const minutes = slot % 2 === 0 ? '00' : '30';
+  return `${hours}:${minutes}`;
+}
+
+function formatSlotRange(slot: number) {
+  const startHours = Math.floor(slot / 2)
+    .toString()
+    .padStart(2, '0');
+  const startMinutes = slot % 2 === 0 ? '00' : '30';
+  const endIndex = slot + 1;
+  const rawEndHours = Math.floor(endIndex / 2);
+  const endHours = Math.min(rawEndHours, 24).toString().padStart(2, '0');
+  const endMinutes = endIndex % 2 === 0 ? '00' : '30';
+  return `${startHours}:${startMinutes} - ${endHours}:${endMinutes}`;
+}
+
+type ToggleSwitchProps = {
+  enabled: boolean;
+  onToggle: () => void;
+  disabled: boolean;
+  label: string;
+};
+
+function ToggleSwitch({
+  enabled,
+  onToggle,
+  disabled,
+  label,
+}: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label={label}
+      aria-disabled={disabled}
+      onClick={onToggle}
+      className={`relative inline-flex h-6 w-11 items-center rounded-full transition focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+        enabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-700'
+      } ${disabled ? 'opacity-60' : 'hover:bg-blue-500/80 dark:hover:bg-gray-600'} cursor-pointer`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
+          enabled ? 'translate-x-5' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+}
+
+export default function WorkSchedulePage() {
+  const { t } = useI18n();
+  const {
+    workSchedule,
+    planningReminder,
+    toggleWorkScheduleSlot,
+    setPlanningReminderEnabled,
+    setPlanningReminderMinutes,
+  } = useStore(state => ({
+    workSchedule: state.workSchedule,
+    planningReminder: state.workPreferences.planningReminder,
+    toggleWorkScheduleSlot: state.toggleWorkScheduleSlot,
+    setPlanningReminderEnabled: state.setPlanningReminderEnabled,
+    setPlanningReminderMinutes: state.setPlanningReminderMinutes,
+  }));
+  const [dragMode, setDragMode] = useState<DragMode | null>(null);
+
+  useEffect(() => {
+    const handlePointerEnd = () => setDragMode(null);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    return () => {
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    };
+  }, []);
+
+  const selectedSlots = useMemo(() => {
+    const map: Record<Weekday, Set<number>> = {
+      monday: new Set(workSchedule.monday ?? []),
+      tuesday: new Set(workSchedule.tuesday ?? []),
+      wednesday: new Set(workSchedule.wednesday ?? []),
+      thursday: new Set(workSchedule.thursday ?? []),
+      friday: new Set(workSchedule.friday ?? []),
+      saturday: new Set(workSchedule.saturday ?? []),
+      sunday: new Set(workSchedule.sunday ?? []),
+    };
+    return map;
+  }, [workSchedule]);
+
+  const hasSchedule = useMemo(
+    () => WEEK_DAYS.some(day => (workSchedule[day]?.length ?? 0) > 0),
+    [workSchedule]
+  );
+
+  const handlePointerDown =
+    (day: Weekday, slot: number) =>
+    (event: PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      const applied = toggleWorkScheduleSlot(day, slot);
+      setDragMode(applied);
+    };
+
+  const handlePointerEnter =
+    (day: Weekday, slot: number) =>
+    (event: PointerEvent<HTMLButtonElement>) => {
+      if (!dragMode) return;
+      event.preventDefault();
+      toggleWorkScheduleSlot(day, slot, dragMode);
+    };
+
+  const handleKeyDown =
+    (day: Weekday, slot: number) =>
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleWorkScheduleSlot(day, slot);
+      }
+    };
+
+  const handleReminderToggle = () => {
+    if (!hasSchedule && !planningReminder.enabled) {
+      toast.error(
+        t('workSchedulePage.actions.planningReminder.fillScheduleFirst')
+      );
+      return;
+    }
+    setPlanningReminderEnabled(!planningReminder.enabled);
+  };
+
+  const handleMinutesChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const minutes = Number.parseInt(event.target.value, 10);
+    if (Number.isNaN(minutes)) {
+      return;
+    }
+    setPlanningReminderMinutes(minutes);
+  };
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-4">
+      <h1 className="text-2xl font-bold">{t('workSchedulePage.title')}</h1>
+      <p>{t('workSchedulePage.intro')}</p>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        {t('workSchedulePage.helper')}
+      </p>
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">
+            {t('workSchedulePage.calendar.title')}
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            {t('workSchedulePage.calendar.instructions')}
+          </p>
+        </div>
+        <div className="overflow-x-auto rounded border border-gray-200 dark:border-gray-700">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-800">
+                <th className="sticky left-0 top-0 z-10 border border-gray-200 px-2 py-2 text-left font-semibold dark:border-gray-700 dark:bg-gray-800">
+                  {t('workSchedulePage.calendar.timeLabel')}
+                </th>
+                {WEEK_DAYS.map(day => (
+                  <th
+                    key={day}
+                    className="min-w-[120px] border border-gray-200 px-2 py-2 text-left font-semibold capitalize dark:border-gray-700"
+                  >
+                    {t(`workSchedulePage.week.${day}`)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {SLOT_INDICES.map(slot => (
+                <tr key={slot}>
+                  <th className="sticky left-0 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-normal dark:border-gray-700 dark:bg-gray-800">
+                    {formatSlotStart(slot)}
+                  </th>
+                  {WEEK_DAYS.map(day => {
+                    const isSelected = selectedSlots[day].has(slot);
+                    const rangeLabel = `${t(
+                      `workSchedulePage.week.${day}`
+                    )} ${formatSlotRange(slot)}`;
+                    return (
+                      <td
+                        key={`${day}-${slot}`}
+                        className="border border-gray-200 p-0 dark:border-gray-700"
+                      >
+                        <button
+                          type="button"
+                          aria-label={rangeLabel}
+                          aria-pressed={isSelected}
+                          onPointerDown={handlePointerDown(day, slot)}
+                          onPointerEnter={handlePointerEnter(day, slot)}
+                          onKeyDown={handleKeyDown(day, slot)}
+                          className={`flex h-8 w-full items-center justify-center text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+                            isSelected
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-white hover:bg-blue-50 dark:bg-gray-900 dark:hover:bg-gray-800'
+                          }`}
+                        >
+                          <span className="sr-only">{rangeLabel}</span>
+                        </button>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">
+          {t('workSchedulePage.actions.title')}
+        </h2>
+        <div className="flex flex-col gap-4 rounded border border-gray-200 p-4 dark:border-gray-700 md:flex-row md:items-center md:justify-between">
+          <div className="flex-1 space-y-2">
+            <h3 className="text-lg font-semibold">
+              {t('workSchedulePage.actions.planningReminder.title')}
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {t('workSchedulePage.actions.planningReminder.description')}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t('workSchedulePage.actions.planningReminder.selectHelper')}
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:gap-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <label
+                htmlFor="planning-reminder-minutes"
+                className="text-sm font-medium"
+              >
+                {t('workSchedulePage.actions.planningReminder.selectLabel')}
+              </label>
+              <select
+                id="planning-reminder-minutes"
+                value={planningReminder.minutesBefore}
+                onChange={handleMinutesChange}
+                disabled={!hasSchedule}
+                className="rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {MINUTE_OPTIONS.map(option => (
+                  <option
+                    key={option}
+                    value={option}
+                  >
+                    {t(
+                      `workSchedulePage.actions.planningReminder.minutes.${option}`
+                    )}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-gray-600 dark:text-gray-300">
+                {t('workSchedulePage.actions.planningReminder.selectSuffix')}
+              </span>
+            </div>
+            <ToggleSwitch
+              enabled={planningReminder.enabled}
+              onToggle={handleReminderToggle}
+              disabled={!hasSchedule}
+              label={t('workSchedulePage.actions.planningReminder.switchLabel')}
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/settings/work-schedule/page.tsx
+++ b/app/settings/work-schedule/page.tsx
@@ -180,133 +180,134 @@ export default function WorkSchedulePage() {
   };
 
   return (
-    <main className="mx-auto max-w-6xl space-y-8 px-4 py-16">
-      <h1 className="text-2xl font-bold">{t('workSchedulePage.title')}</h1>
-      <div className="space-y-3">
-        <p>{t('workSchedulePage.intro')}</p>
-        <p className="text-base font-medium">
-          {t('workSchedulePage.calendar.instructions')}
-        </p>
-      </div>
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">
-          {t('workSchedulePage.calendar.title')}
-        </h2>
-        <div
-          ref={calendarRef}
-          className="max-h-[520px] overflow-auto rounded border border-gray-200 dark:border-gray-700"
-        >
-          <table className="w-full border-collapse text-sm">
-            <thead>
-              <tr className="bg-gray-50 dark:bg-gray-800">
-                <th className="sticky left-0 top-0 z-10 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold dark:border-gray-700 dark:bg-gray-800">
-                  {t('workSchedulePage.calendar.timeLabel')}
-                </th>
-                {WEEK_DAYS.map(day => (
-                  <th
-                    key={day}
-                    className="sticky top-0 z-10 min-w-[120px] border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold capitalize dark:border-gray-700 dark:bg-gray-800"
-                  >
-                    {t(`workSchedulePage.week.${day}`)}
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-6xl flex-col gap-8 px-4 py-16">
+        <h1 className="text-2xl font-bold">{t('workSchedulePage.title')}</h1>
+        <div className="space-y-3">
+          <p>{t('workSchedulePage.intro')}</p>
+          <p className="text-base font-medium">
+            {t('workSchedulePage.calendar.instructions')}
+          </p>
+        </div>
+        <section className="flex min-h-0 flex-col gap-4">
+          <div
+            ref={calendarRef}
+            className="max-h-[520px] flex-1 overflow-auto rounded border border-gray-200 dark:border-gray-700"
+          >
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-800">
+                  <th className="sticky left-0 top-0 z-10 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold dark:border-gray-700 dark:bg-gray-800">
+                    {t('workSchedulePage.calendar.timeLabel')}
                   </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {SLOT_INDICES.map(slot => (
-                <tr key={slot}>
-                  <th className="sticky left-0 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-normal dark:border-gray-700 dark:bg-gray-800">
-                    {formatSlotStart(slot)}
-                  </th>
-                  {WEEK_DAYS.map(day => {
-                    const isSelected = selectedSlots[day].has(slot);
-                    const rangeLabel = `${t(
-                      `workSchedulePage.week.${day}`
-                    )} ${formatSlotRange(slot)}`;
-                    return (
-                      <td
-                        key={`${day}-${slot}`}
-                        className="border border-gray-200 p-0 dark:border-gray-700"
-                      >
-                        <button
-                          type="button"
-                          aria-label={rangeLabel}
-                          aria-pressed={isSelected}
-                          onPointerDown={handlePointerDown(day, slot)}
-                          onPointerEnter={handlePointerEnter(day, slot)}
-                          onKeyDown={handleKeyDown(day, slot)}
-                          className={`flex h-8 w-full items-center justify-center text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
-                            isSelected
-                              ? 'bg-blue-600 text-white'
-                              : 'bg-white hover:bg-blue-50 dark:bg-gray-900 dark:hover:bg-gray-800'
-                          }`}
-                        >
-                          <span className="sr-only">{rangeLabel}</span>
-                        </button>
-                      </td>
-                    );
-                  })}
+                  {WEEK_DAYS.map(day => (
+                    <th
+                      key={day}
+                      className="sticky top-0 z-10 min-w-[120px] border border-gray-200 bg-gray-50 px-2 py-2 text-left font-semibold capitalize dark:border-gray-700 dark:bg-gray-800"
+                    >
+                      {t(`workSchedulePage.week.${day}`)}
+                    </th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">
-          {t('workSchedulePage.actions.title')}
-        </h2>
-        <div className="flex flex-col gap-4 rounded border border-gray-200 p-4 dark:border-gray-700 md:flex-row md:items-center md:justify-between">
-          <div className="flex-1 space-y-2">
-            <h3 className="text-lg font-semibold">
-              {t('workSchedulePage.actions.planningReminder.title')}
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-300">
-              {t('workSchedulePage.actions.planningReminder.description')}
-            </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              {t('workSchedulePage.actions.planningReminder.selectHelper')}
-            </p>
-          </div>
-          <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:gap-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <label
-                htmlFor="planning-reminder-minutes"
-                className="text-sm font-medium"
-              >
-                {t('workSchedulePage.actions.planningReminder.selectLabel')}
-              </label>
-              <select
-                id="planning-reminder-minutes"
-                value={planningReminder.minutesBefore}
-                onChange={handleMinutesChange}
-                disabled={!hasSchedule}
-                className="rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {MINUTE_OPTIONS.map(option => (
-                  <option
-                    key={option}
-                    value={option}
-                  >
-                    {t(
-                      `workSchedulePage.actions.planningReminder.minutes.${option}`
-                    )}
-                  </option>
+              </thead>
+              <tbody>
+                {SLOT_INDICES.map(slot => (
+                  <tr key={slot}>
+                    <th className="sticky left-0 border border-gray-200 bg-gray-50 px-2 py-2 text-left font-normal dark:border-gray-700 dark:bg-gray-800">
+                      {formatSlotStart(slot)}
+                    </th>
+                    {WEEK_DAYS.map(day => {
+                      const isSelected = selectedSlots[day].has(slot);
+                      const rangeLabel = `${t(
+                        `workSchedulePage.week.${day}`
+                      )} ${formatSlotRange(slot)}`;
+                      return (
+                        <td
+                          key={`${day}-${slot}`}
+                          className="border border-gray-200 p-0 dark:border-gray-700"
+                        >
+                          <button
+                            type="button"
+                            aria-label={rangeLabel}
+                            aria-pressed={isSelected}
+                            onPointerDown={handlePointerDown(day, slot)}
+                            onPointerEnter={handlePointerEnter(day, slot)}
+                            onKeyDown={handleKeyDown(day, slot)}
+                            className={`flex h-8 w-full items-center justify-center text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+                              isSelected
+                                ? 'bg-blue-600 text-white'
+                                : 'bg-white hover:bg-blue-50 dark:bg-gray-900 dark:hover:bg-gray-800'
+                            }`}
+                          >
+                            <span className="sr-only">{rangeLabel}</span>
+                          </button>
+                        </td>
+                      );
+                    })}
+                  </tr>
                 ))}
-              </select>
-              <span className="text-sm text-gray-600 dark:text-gray-300">
-                {t('workSchedulePage.actions.planningReminder.selectSuffix')}
-              </span>
-            </div>
-            <ToggleSwitch
-              enabled={planningReminder.enabled}
-              onToggle={handleReminderToggle}
-              disabled={!hasSchedule}
-              label={t('workSchedulePage.actions.planningReminder.switchLabel')}
-            />
+              </tbody>
+            </table>
           </div>
-        </div>
-      </section>
-    </main>
+        </section>
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">
+            {t('workSchedulePage.actions.title')}
+          </h2>
+          <div className="flex flex-col gap-4 rounded border border-gray-200 p-4 dark:border-gray-700 md:flex-row md:items-center md:justify-between">
+            <div className="flex-1 space-y-2">
+              <h3 className="text-lg font-semibold">
+                {t('workSchedulePage.actions.planningReminder.title')}
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {t('workSchedulePage.actions.planningReminder.description')}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t('workSchedulePage.actions.planningReminder.selectHelper')}
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:gap-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <label
+                  htmlFor="planning-reminder-minutes"
+                  className="text-sm font-medium"
+                >
+                  {t('workSchedulePage.actions.planningReminder.selectLabel')}
+                </label>
+                <select
+                  id="planning-reminder-minutes"
+                  value={planningReminder.minutesBefore}
+                  onChange={handleMinutesChange}
+                  disabled={!hasSchedule}
+                  className="rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {MINUTE_OPTIONS.map(option => (
+                    <option
+                      key={option}
+                      value={option}
+                    >
+                      {t(
+                        `workSchedulePage.actions.planningReminder.minutes.${option}`
+                      )}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-sm text-gray-600 dark:text-gray-300">
+                  {t('workSchedulePage.actions.planningReminder.selectSuffix')}
+                </span>
+              </div>
+              <ToggleSwitch
+                enabled={planningReminder.enabled}
+                onToggle={handleReminderToggle}
+                disabled={!hasSchedule}
+                label={t(
+                  'workSchedulePage.actions.planningReminder.switchLabel'
+                )}
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -7,7 +7,7 @@ export default function TermsPage() {
   const { t } = useI18n();
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
       <h1 className="text-2xl font-bold">{t('termsPage.title')}</h1>
       <p>{t('termsPage.intro')}</p>
       <h2 className="text-xl font-semibold">{t('termsPage.usage.title')}</h2>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import {
   Moon,
   Settings,
   Bell,
+  CalendarClock,
 } from 'lucide-react';
 import { Language, LANGUAGES } from '../../lib/i18n';
 import Icon from '../Icon/Icon';
@@ -194,6 +195,14 @@ export default function Header() {
                 )}
                 {t('actions.toggleTheme')}
               </button>
+              <Link
+                href="/settings/work-schedule"
+                onClick={() => setShowActions(false)}
+                className="flex items-center gap-2 rounded px-2 py-2 hover:bg-gray-200 dark:hover:bg-gray-800"
+              >
+                <CalendarClock className="h-4 w-4" />{' '}
+                {t('actions.workSchedule')}
+              </Link>
               <div className="mt-2 border-t pt-2">
                 <label
                   htmlFor="language-select"

--- a/components/WorkScheduleManager/WorkScheduleManager.tsx
+++ b/components/WorkScheduleManager/WorkScheduleManager.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+import { useI18n } from '../../lib/i18n';
+import { useStore } from '../../lib/store';
+import type { Weekday } from '../../lib/types';
+
+const DAY_FROM_INDEX: Record<number, Weekday> = {
+  0: 'sunday',
+  1: 'monday',
+  2: 'tuesday',
+  3: 'wednesday',
+  4: 'thursday',
+  5: 'friday',
+  6: 'saturday',
+};
+
+function getDayKey(date: Date): Weekday {
+  return DAY_FROM_INDEX[date.getDay()];
+}
+
+function getSlotEndTimestamp(baseDate: Date, slot: number): number {
+  const end = new Date(baseDate);
+  const endIndex = slot + 1;
+  const hours = Math.floor(endIndex / 2);
+  const minutes = endIndex % 2 === 0 ? 0 : 30;
+  end.setHours(hours, minutes, 0, 0);
+  return end.getTime();
+}
+
+function getReminderTimestamp(
+  baseDate: Date,
+  slot: number,
+  minutesBefore: number
+) {
+  return getSlotEndTimestamp(baseDate, slot) - minutesBefore * 60 * 1000;
+}
+
+export default function WorkScheduleManager() {
+  const { t } = useI18n();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const state = useStore.getState();
+      const reminder = state.workPreferences.planningReminder;
+      if (!reminder.enabled) {
+        return;
+      }
+
+      const today = new Date();
+      const dayKey = getDayKey(today);
+      const slots = state.workSchedule[dayKey];
+      if (!slots || slots.length === 0) {
+        return;
+      }
+
+      const sortedSlots = [...slots].sort((a, b) => a - b);
+      const lastSlot = sortedSlots[sortedSlots.length - 1];
+      const reminderAt = getReminderTimestamp(
+        today,
+        lastSlot,
+        reminder.minutesBefore
+      );
+      const endAt = getSlotEndTimestamp(today, lastSlot);
+      const now = Date.now();
+
+      if (now >= reminderAt && now < endAt) {
+        const todayKey = today.toISOString().slice(0, 10);
+        if (reminder.lastNotifiedDate === todayKey) {
+          return;
+        }
+
+        state.setPlanningReminderLastNotified(todayKey);
+        toast(t('workSchedulePage.reminder.toast'), { duration: 8000 });
+        const randomId =
+          typeof globalThis.crypto?.randomUUID === 'function'
+            ? globalThis.crypto.randomUUID()
+            : `${Date.now().toString(36)}`;
+        state.addNotification({
+          id: `work-reminder-${todayKey}-${randomId}`,
+          type: 'tip',
+          titleKey: 'notifications.workReminder.title',
+          descriptionKey: 'notifications.workReminder.description',
+          read: false,
+          createdAt: new Date().toISOString(),
+        });
+      }
+    }, 30000);
+
+    return () => clearInterval(interval);
+  }, [t]);
+
+  return null;
+}

--- a/lib/__tests__/workSchedule.test.ts
+++ b/lib/__tests__/workSchedule.test.ts
@@ -1,0 +1,51 @@
+import { useStore } from '../store';
+
+describe('work schedule store', () => {
+  const initialState = useStore.getState();
+
+  beforeEach(() => {
+    useStore.setState(initialState, true);
+    localStorage.clear();
+  });
+
+  afterAll(() => {
+    useStore.setState(initialState, true);
+    localStorage.clear();
+  });
+
+  it('adds and removes slots when toggling', () => {
+    const addMode = useStore.getState().toggleWorkScheduleSlot('monday', 10);
+    expect(addMode).toBe('add');
+    expect(useStore.getState().workSchedule.monday).toContain(10);
+
+    const removeMode = useStore.getState().toggleWorkScheduleSlot('monday', 10);
+    expect(removeMode).toBe('remove');
+    expect(useStore.getState().workSchedule.monday).not.toContain(10);
+  });
+
+  it('respects explicit mode when dragging', () => {
+    useStore.getState().toggleWorkScheduleSlot('tuesday', 5, 'add');
+    useStore.getState().toggleWorkScheduleSlot('tuesday', 5, 'add');
+    expect(useStore.getState().workSchedule.tuesday).toEqual([5]);
+
+    useStore.getState().toggleWorkScheduleSlot('tuesday', 5, 'remove');
+    expect(useStore.getState().workSchedule.tuesday).toEqual([]);
+  });
+
+  it('updates reminder preferences', () => {
+    useStore.getState().setPlanningReminderMinutes(30);
+    expect(
+      useStore.getState().workPreferences.planningReminder.minutesBefore
+    ).toBe(30);
+
+    useStore.getState().setPlanningReminderEnabled(true);
+    expect(useStore.getState().workPreferences.planningReminder.enabled).toBe(
+      true
+    );
+
+    useStore.getState().setPlanningReminderLastNotified('2024-05-20');
+    expect(
+      useStore.getState().workPreferences.planningReminder.lastNotifiedDate
+    ).toBe('2024-05-20');
+  });
+});

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -116,7 +116,6 @@ const translations: Record<Language, any> = {
       intro:
         'Save your working hours so Local Quick Planner can adapt to your workday.',
       calendar: {
-        title: 'Weekly hours',
         instructions:
           'Click and drag over the half-hour slots to mark when your workday starts and ends each day.',
         timeLabel: 'Time',
@@ -388,7 +387,6 @@ const translations: Record<Language, any> = {
       intro:
         'Guarda tu horario laboral para que Local Quick Planner se adapte a tu jornada.',
       calendar: {
-        title: 'Horario semanal',
         instructions:
           'Haz clic y arrastra sobre los bloques de media hora para marcar cuándo empieza y termina tu jornada cada día.',
         timeLabel: 'Hora',

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -115,8 +115,6 @@ const translations: Record<Language, any> = {
       title: 'Work schedule',
       intro:
         'Save your working hours so Local Quick Planner can adapt to your workday.',
-      helper:
-        'For example, you can set a reminder to arrive 15 minutes before the end of each workday so you can plan the next day.',
       calendar: {
         title: 'Weekly hours',
         instructions:
@@ -389,8 +387,6 @@ const translations: Record<Language, any> = {
       title: 'Jornada laboral',
       intro:
         'Guarda tu horario laboral para que Local Quick Planner se adapte a tu jornada.',
-      helper:
-        'Por ejemplo, puedes configurar un recordatorio para que llegue 15 minutos antes de terminar cada jornada y así planificar el día siguiente.',
       calendar: {
         title: 'Horario semanal',
         instructions:

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -22,6 +22,7 @@ const translations: Record<Language, any> = {
       language: 'Select language',
       more: 'More actions',
       settings: 'Settings',
+      workSchedule: 'Work schedule',
       removeTag: 'Remove tag',
       addTag: 'Add tag',
       favoriteTag: 'Add tag to favorites',
@@ -103,6 +104,57 @@ const translations: Record<Language, any> = {
         title: 'Welcome to Local Quick Planner',
         description:
           'Use the "My Tasks" board to collect and prioritize everything you need to do. Move items into "My Day" when you are ready to focus on them. Open settings to switch theme, export your data and more.',
+      },
+      workReminder: {
+        title: 'Plan tomorrow',
+        description:
+          'Your workday is about to finish. Review your progress and decide what comes next.',
+      },
+    },
+    workSchedulePage: {
+      title: 'Work schedule',
+      intro:
+        'Save your working hours so Local Quick Planner can adapt to your workday.',
+      helper:
+        'For example, you can set a reminder to arrive 15 minutes before the end of each workday so you can plan the next day.',
+      calendar: {
+        title: 'Weekly hours',
+        instructions:
+          'Click and drag over the half-hour slots to mark when your workday starts and ends each day.',
+        timeLabel: 'Time',
+      },
+      week: {
+        monday: 'Monday',
+        tuesday: 'Tuesday',
+        wednesday: 'Wednesday',
+        thursday: 'Thursday',
+        friday: 'Friday',
+        saturday: 'Saturday',
+        sunday: 'Sunday',
+      },
+      actions: {
+        title: 'Available actions',
+        planningReminder: {
+          title: 'Reminder to plan tomorrow',
+          description:
+            'Receive a reminder shortly before your workday ends so you can organize the next day.',
+          selectLabel: 'Notify me',
+          selectSuffix: 'before the end of my workday',
+          selectHelper:
+            'Select how long before finishing you want to receive the reminder.',
+          minutes: {
+            '5': '5m',
+            '15': '15m',
+            '30': '30m',
+            '60': '1h',
+          },
+          switchLabel: 'Enable reminder',
+          fillScheduleFirst:
+            'Set your work schedule before activating this reminder.',
+        },
+      },
+      reminder: {
+        toast: 'Your workday is about to end. Take a moment to plan tomorrow.',
       },
     },
     footer: {
@@ -244,6 +296,7 @@ const translations: Record<Language, any> = {
       language: 'Seleccionar idioma',
       more: 'Más acciones',
       settings: 'Ajustes',
+      workSchedule: 'Jornada laboral',
       removeTag: 'Eliminar etiqueta',
       addTag: 'Añadir etiqueta',
       favoriteTag: 'Marcar etiqueta como favorita',
@@ -325,6 +378,58 @@ const translations: Record<Language, any> = {
         title: '¡Hola! Te damos la bienvenida a Local Quick Planner',
         description:
           'Usa el tablero "Mis Tareas" para reunir y priorizar todo lo que debes hacer. Pasa los elementos a "Mi Día" cuando quieras enfocarte en ellos. Abre los ajustes para cambiar el tema, exportar tus datos y más.',
+      },
+      workReminder: {
+        title: 'Planifica el mañana',
+        description:
+          'Tu jornada está a punto de terminar. Revisa tu progreso y decide los siguientes pasos.',
+      },
+    },
+    workSchedulePage: {
+      title: 'Jornada laboral',
+      intro:
+        'Guarda tu horario laboral para que Local Quick Planner se adapte a tu jornada.',
+      helper:
+        'Por ejemplo, puedes configurar un recordatorio para que llegue 15 minutos antes de terminar cada jornada y así planificar el día siguiente.',
+      calendar: {
+        title: 'Horario semanal',
+        instructions:
+          'Haz clic y arrastra sobre los bloques de media hora para marcar cuándo empieza y termina tu jornada cada día.',
+        timeLabel: 'Hora',
+      },
+      week: {
+        monday: 'Lunes',
+        tuesday: 'Martes',
+        wednesday: 'Miércoles',
+        thursday: 'Jueves',
+        friday: 'Viernes',
+        saturday: 'Sábado',
+        sunday: 'Domingo',
+      },
+      actions: {
+        title: 'Acciones disponibles',
+        planningReminder: {
+          title: 'Recordatorio para planificar el siguiente día',
+          description:
+            'Recibe un aviso poco antes de finalizar tu jornada para organizar el trabajo del día siguiente.',
+          selectLabel: 'Avísame',
+          selectSuffix: 'antes de que termine mi jornada',
+          selectHelper:
+            'Selecciona cuánto tiempo antes quieres recibir el aviso.',
+          minutes: {
+            '5': '5m',
+            '15': '15m',
+            '30': '30m',
+            '60': '1h',
+          },
+          switchLabel: 'Activar recordatorio',
+          fillScheduleFirst:
+            'Rellena tu jornada laboral antes de activar este recordatorio.',
+        },
+      },
+      reminder: {
+        toast:
+          'Tu jornada está a punto de terminar. Tómate un momento para planificar el próximo día.',
       },
     },
     footer: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,25 @@ export type TaskTimer = {
   endsAt: string | null;
 };
 
+export type Weekday =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export type WorkSchedule = Record<Weekday, number[]>;
+
+export type WorkPreferences = {
+  planningReminder: {
+    enabled: boolean;
+    minutesBefore: number;
+    lastNotifiedDate: string | null;
+  };
+};
+
 export type PersistedState = {
   tasks: Task[];
   lists: List[];
@@ -36,6 +55,8 @@ export type PersistedState = {
   order: Record<string, string[]>;
   notifications: Notification[];
   timers: Record<string, TaskTimer>;
+  workSchedule: WorkSchedule;
+  workPreferences: WorkPreferences;
   version: number;
 };
 


### PR DESCRIPTION
## Summary
- add a settings view to configure the weekly work schedule and reminder lead time
- persist work schedule data and reminder preferences in the store with translations and header access
- introduce a background manager and tests to fire daily planning reminders

## Testing
- npm run lint
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8f4e4aa88832c857162cd85029dde