### PR TITLE
Sort My Day todo tasks by priority

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -502,7 +502,31 @@ export const useStore = create<Store>((set, get) => ({
         task.plannedFor = today;
         task.dayStatus = 'todo';
         const key = 'day-todo';
-        newOrder[key] = [...(newOrder[key] || []), id];
+        const priorityOrder: Record<Priority, number> = {
+          high: 0,
+          medium: 1,
+          low: 2,
+        };
+        const todoOrder = (newOrder[key] || []).filter(tid => tid !== id);
+        const newTaskPriority = task.priority;
+        const insertIndex = todoOrder.findIndex(tid => {
+          const existingTask =
+            tid === id ? task : state.tasks.find(t => t.id === tid);
+          if (!existingTask) {
+            return false;
+          }
+          const existingPriority =
+            priorityOrder[existingTask.priority] ?? priorityOrder.medium;
+          return existingPriority > priorityOrder[newTaskPriority];
+        });
+        newOrder[key] =
+          insertIndex === -1
+            ? [...todoOrder, id]
+            : [
+                ...todoOrder.slice(0, insertIndex),
+                id,
+                ...todoOrder.slice(insertIndex),
+              ];
         const existingTimer = timers[id];
         timers[id] = existingTimer
           ? {


### PR DESCRIPTION
## Summary
- insert tasks added to My Day's todo column according to their priority so higher priority items appear first
- keep existing timer initialization when planning tasks for today

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca42854008832c8b7fad91a589d001