### PR TITLE
Add onboarding tooltip for first task addition

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -16,6 +16,8 @@ import { CSS } from '@dnd-kit/utilities';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
 import Link from '../Link/Link';
 
+const BASE_TOOLTIP_OFFSET = -72;
+
 interface TaskItemProps extends UseTaskItemProps {
   highlighted?: boolean;
   showMyDayHelp?: boolean;
@@ -153,7 +155,7 @@ export default function TaskItem({
             ref={tooltipRef}
             className="absolute top-full left-1/2 z-30 mt-3 w-64 rounded-lg border border-white bg-gray-900 px-3 py-2 text-xs text-white shadow-lg"
             style={{
-              transform: `translateX(calc(-50% + ${tooltipShift}px))`,
+              transform: `translateX(calc(-50% + ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
             }}
           >
             <div className="flex items-start gap-2">
@@ -174,7 +176,7 @@ export default function TaskItem({
               aria-hidden="true"
               className="absolute left-1/2 bottom-full border-[6px] border-transparent border-b-gray-900"
               style={{
-                transform: `translateX(calc(-50% - ${tooltipShift}px))`,
+                transform: `translateX(calc(-50% - ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
               }}
             />
           </div>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -113,7 +113,7 @@ export default function TaskItem({
           )}
         </button>
         {showHelp && (
-          <div className="absolute bottom-full left-1/2 z-30 mb-3 w-64 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
+          <div className="absolute top-full left-1/2 z-30 mt-3 w-64 -translate-x-1/2 rounded-lg border border-white bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
             <div className="flex items-start gap-2">
               <HelpCircle className="mt-[2px] h-4 w-4 flex-shrink-0" />
               <span className="flex-1 leading-snug">
@@ -130,7 +130,7 @@ export default function TaskItem({
             </div>
             <span
               aria-hidden="true"
-              className="absolute left-1/2 top-full -translate-x-1/2 border-[6px] border-transparent border-t-gray-900"
+              className="absolute left-1/2 bottom-full -translate-x-1/2 border-[6px] border-transparent border-b-gray-900"
             />
           </div>
         )}

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -100,7 +100,11 @@ export default function TaskItem({
           title={
             task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
           }
-          className="rounded bg-transparent p-1 text-black focus:ring dark:text-white"
+          className={`rounded bg-transparent p-1 text-black focus:ring dark:text-white ${
+            showHelp
+              ? 'ring-2 ring-[#57886C] ring-offset-2 ring-offset-gray-100 animate-pulse dark:ring-offset-gray-900'
+              : ''
+          }`}
         >
           {task.plannedFor ? (
             <CalendarX className="h-4 w-4" />
@@ -109,7 +113,7 @@ export default function TaskItem({
           )}
         </button>
         {showHelp && (
-          <div className="absolute -top-24 left-1/2 z-30 w-64 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
+          <div className="absolute bottom-full left-1/2 z-30 mb-3 w-64 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
             <div className="flex items-start gap-2">
               <HelpCircle className="mt-[2px] h-4 w-4 flex-shrink-0" />
               <span className="flex-1 leading-snug">
@@ -126,7 +130,7 @@ export default function TaskItem({
             </div>
             <span
               aria-hidden="true"
-              className="absolute left-1/2 top-full -translate-x-1/2 border-8 border-transparent border-t-gray-900"
+              className="absolute left-1/2 top-full -translate-x-1/2 border-[6px] border-transparent border-t-gray-900"
             />
           </div>
         )}

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -5,7 +5,7 @@ import {
   Trash2,
   GripVertical,
   Plus,
-  CircleHelp,
+  HelpCircle,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Priority, Tag } from '../../lib/types';
@@ -111,7 +111,7 @@ export default function TaskItem({
         {showHelp && (
           <div className="absolute -top-24 left-1/2 z-30 w-64 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
             <div className="flex items-start gap-2">
-              <CircleHelp className="mt-[2px] h-4 w-4 flex-shrink-0" />
+              <HelpCircle className="mt-[2px] h-4 w-4 flex-shrink-0" />
               <span className="flex-1 leading-snug">
                 {t('taskItem.myDayHelp')}
               </span>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -5,6 +5,7 @@ import {
   Trash2,
   GripVertical,
   Plus,
+  CircleHelp,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Priority, Tag } from '../../lib/types';
@@ -17,9 +18,16 @@ import Link from '../Link/Link';
 
 interface TaskItemProps extends UseTaskItemProps {
   highlighted?: boolean;
+  showMyDayHelp?: boolean;
+  onCloseMyDayHelp?: () => void;
 }
 
-export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
+export default function TaskItem({
+  taskId,
+  highlighted,
+  showMyDayHelp = false,
+  onCloseMyDayHelp,
+}: TaskItemProps) {
   const { state, actions } = useTaskItem({ taskId });
   const { task, isEditing, title, allTags, showTagInput } = state as any;
   const {
@@ -56,7 +64,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
     return null;
   }
 
-  const Actions = () => (
+  const Actions = ({ showHelp }: { showHelp?: boolean }) => (
     <>
       {isPriorityEditing ? (
         <select
@@ -83,22 +91,46 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           <span>{priorityLabels[task.priority as Priority]}</span>
         </button>
       )}
-      <button
-        onClick={() => toggleMyDay(task.id)}
-        aria-label={
-          task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-        }
-        title={
-          task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-        }
-        className="rounded bg-transparent p-1 text-black focus:ring dark:text-white"
-      >
-        {task.plannedFor ? (
-          <CalendarX className="h-4 w-4" />
-        ) : (
-          <CalendarPlus className="h-4 w-4" />
+      <div className="relative flex items-center">
+        <button
+          onClick={() => toggleMyDay(task.id)}
+          aria-label={
+            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
+          }
+          title={
+            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
+          }
+          className="rounded bg-transparent p-1 text-black focus:ring dark:text-white"
+        >
+          {task.plannedFor ? (
+            <CalendarX className="h-4 w-4" />
+          ) : (
+            <CalendarPlus className="h-4 w-4" />
+          )}
+        </button>
+        {showHelp && (
+          <div className="absolute -top-24 left-1/2 z-30 w-64 -translate-x-1/2 rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg">
+            <div className="flex items-start gap-2">
+              <CircleHelp className="mt-[2px] h-4 w-4 flex-shrink-0" />
+              <span className="flex-1 leading-snug">
+                {t('taskItem.myDayHelp')}
+              </span>
+              <button
+                type="button"
+                onClick={() => onCloseMyDayHelp?.()}
+                aria-label={t('actions.close')}
+                className="ml-2 text-white transition hover:opacity-80"
+              >
+                ×
+              </button>
+            </div>
+            <span
+              aria-hidden="true"
+              className="absolute left-1/2 top-full -translate-x-1/2 border-8 border-transparent border-t-gray-900"
+            />
+          </div>
         )}
-      </button>
+      </div>
       <button
         onClick={() => removeTask(task.id)}
         aria-label={t('taskItem.deleteTask')}
@@ -150,7 +182,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
             </p>
           )}
           <div className="hidden md:flex items-center gap-2 md:self-start">
-            <Actions />
+            <Actions showHelp={showMyDayHelp} />
           </div>
         </div>
         <div className="flex items-center gap-2 mt-2">
@@ -216,7 +248,7 @@ export default function TaskItem({ taskId, highlighted }: TaskItemProps) {
           )}
         </div>
         <div className="flex items-center gap-2 md:hidden">
-          <Actions />
+          <Actions showHelp={showMyDayHelp} />
         </div>
       </div>
     </div>

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -93,7 +93,7 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
 
     const timeout = window.setTimeout(() => {
       hideMyDayHelp();
-    }, 5000);
+    }, 9000);
 
     return () => window.clearTimeout(timeout);
   }, [showMyDayHelp, hideMyDayHelp]);

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -20,9 +20,14 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
   const { handleDragEnd } = actions;
   const [myDayHelpTaskId, setMyDayHelpTaskId] = useState<string | null>(null);
   const [showMyDayHelp, setShowMyDayHelp] = useState(false);
+  const showHelpDelayRef = useRef<number | null>(null);
   const previousLengthRef = useRef(tasks.length);
   const hasShownHelpRef = useRef(false);
   const hideMyDayHelp = useCallback(() => {
+    if (showHelpDelayRef.current !== null) {
+      window.clearTimeout(showHelpDelayRef.current);
+      showHelpDelayRef.current = null;
+    }
     setShowMyDayHelp(false);
     setMyDayHelpTaskId(null);
   }, []);
@@ -53,7 +58,13 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
 
         if (shouldShowHelp) {
           setMyDayHelpTaskId(firstTask.id);
-          setShowMyDayHelp(true);
+          if (showHelpDelayRef.current !== null) {
+            window.clearTimeout(showHelpDelayRef.current);
+          }
+          showHelpDelayRef.current = window.setTimeout(() => {
+            setShowMyDayHelp(true);
+            showHelpDelayRef.current = null;
+          }, 3000);
         }
 
         hasShownHelpRef.current = true;
@@ -66,6 +77,14 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
 
     previousLengthRef.current = tasks.length;
   }, [tasks, hideMyDayHelp]);
+
+  useEffect(() => {
+    return () => {
+      if (showHelpDelayRef.current !== null) {
+        window.clearTimeout(showHelpDelayRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!showMyDayHelp) {

--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -93,7 +93,7 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
 
     const timeout = window.setTimeout(() => {
       hideMyDayHelp();
-    }, 9000);
+    }, 5000);
 
     return () => window.clearTimeout(timeout);
   }, [showMyDayHelp, hideMyDayHelp]);

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -65,6 +65,7 @@ const translations: Record<Language, any> = {
       addMyDay: 'Add to My Day',
       deleteTask: 'Delete task',
       tagPlaceholder: 'Add tag',
+      myDayHelp: 'Plan your daily work by adding tasks to My Day.',
     },
     myDayPage: {
       empty: 'No tasks added to My Day',
@@ -336,6 +337,7 @@ const translations: Record<Language, any> = {
       addMyDay: 'Agregar a Mi Día',
       deleteTask: 'Eliminar tarea',
       tagPlaceholder: 'Añadir etiqueta',
+      myDayHelp: 'Planifica tu trabajo diario añadiendo tareas a Mi Día.',
     },
     myDayPage: {
       empty: 'No hay tareas añadidas a Mi Día',


### PR DESCRIPTION
## Summary
- show a contextual help tooltip when the very first task is created
- highlight the My Day action on the new task with a help icon, close button, and auto-hide after 5 seconds
- persist tooltip dismissal across sessions and add translations for the new message

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca45ebde64832cbbf1765a12c776f2