### PR TITLE
Add day status icons to My Day tasks and columns

### DIFF
--- a/components/Board/Board.tsx
+++ b/components/Board/Board.tsx
@@ -26,6 +26,7 @@ export default function Board(props: UseBoardProps) {
             title={col.title}
             tasks={getTasks(col.id)}
             mode={props.mode}
+            status={col.status}
           />
         ))}
       </div>

--- a/components/Board/useBoard.ts
+++ b/components/Board/useBoard.ts
@@ -11,6 +11,7 @@ import {
   DragOverEvent,
 } from '@dnd-kit/core';
 import { Task } from '../../lib/types';
+import type { DayStatus } from '../../lib/dayStatus';
 import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
 export interface UseBoardProps {
@@ -25,12 +26,12 @@ export default function useBoard({ mode }: UseBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const { t } = useI18n();
 
-  const columns =
+  const columns: Array<{ id: string; title: string; status?: DayStatus }> =
     mode === 'my-day'
       ? [
-          { id: 'todo', title: t('board.todo') },
-          { id: 'doing', title: t('board.doing') },
-          { id: 'done', title: t('board.done') },
+          { id: 'todo', title: t('board.todo'), status: 'todo' },
+          { id: 'doing', title: t('board.doing'), status: 'doing' },
+          { id: 'done', title: t('board.done'), status: 'done' },
         ]
       : [...lists]
           .sort((a, b) => a.order - b.order)

--- a/components/Column/Column.tsx
+++ b/components/Column/Column.tsx
@@ -4,25 +4,42 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { Task } from '../../lib/types';
+import { getDayStatusIcon, type DayStatus } from '../../lib/dayStatus';
 import TaskCard from '../TaskCard/TaskCard';
 import useColumn, { UseColumnProps } from './useColumn';
 
 interface ColumnProps extends UseColumnProps {
   title: string;
   tasks: Task[];
+  status?: DayStatus;
 }
 
-export default function Column({ id, title, tasks, mode }: ColumnProps) {
+export default function Column({
+  id,
+  title,
+  tasks,
+  mode,
+  status,
+}: ColumnProps) {
   const { state, actions } = useColumn({ id, mode });
   const { containerClasses, listClasses } = state;
   const { setNodeRef } = actions;
+  const StatusIcon = status ? getDayStatusIcon(status) : null;
 
   return (
     <div
       ref={setNodeRef}
       className={containerClasses}
     >
-      <h2 className="mb-2 text-lg font-semibold">{title}</h2>
+      <h2 className="mb-2 flex items-center gap-2 text-lg font-semibold">
+        {StatusIcon ? (
+          <StatusIcon
+            aria-hidden="true"
+            className="h-5 w-5 text-blue-600 dark:text-blue-200"
+          />
+        ) : null}
+        {title}
+      </h2>
       <SortableContext
         id={id}
         items={tasks.map(t => t.id)}

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -214,12 +214,15 @@ export default function TaskItem({
         <GripVertical className="h-4 w-4 text-gray-500" />
       </div>
       <div
-        className={`flex flex-1 min-w-0 overflow-hidden rounded ${
+        className={`flex flex-1 min-w-0 rounded ${
           highlighted ? 'ring-2 ring-[#57886C]' : ''
         }`}
       >
         {isInMyDay && (
-          <div className="flex w-12 flex-none items-center justify-center bg-blue-100 text-blue-700 dark:bg-[rgb(62,74,113)] dark:text-white md:w-14">
+          <div
+            className="flex w-12 flex-none items-center justify-center rounded-l bg-blue-100 text-blue-700 dark:bg-[rgb(62,74,113)] dark:text-white md:w-14"
+            title={statusLabel ?? undefined}
+          >
             {StatusIcon ? (
               <>
                 <StatusIcon

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -239,7 +239,7 @@ export default function TaskItem({
           </div>
         )}
         <div
-          className={`flex flex-col gap-2 p-2 flex-1 min-w-0 ${
+          className={`flex flex-col gap-2 p-4 flex-1 min-w-0 ${
             isInMyDay ? 'rounded-r' : 'rounded'
           } ${
             highlighted

--- a/lib/dayStatus.ts
+++ b/lib/dayStatus.ts
@@ -1,0 +1,21 @@
+import type { LucideIcon } from 'lucide-react';
+import { CheckCircle2, Circle, Loader2 } from 'lucide-react';
+import type { Task } from './types';
+
+export type DayStatus = NonNullable<Task['dayStatus']>;
+
+export const DAY_STATUS_ICONS: Record<DayStatus, LucideIcon> = {
+  todo: Circle,
+  doing: Loader2,
+  done: CheckCircle2,
+};
+
+export function getDayStatusIcon(
+  status?: Task['dayStatus']
+): LucideIcon | null {
+  if (!status) {
+    return null;
+  }
+
+  return DAY_STATUS_ICONS[status];
+}


### PR DESCRIPTION
## Summary
- show the appropriate day-status icon on My Tasks entries that are scheduled for My Day, using a wider accent bar with adaptive colors
- surface the same icons on the My Day board column headers by sharing a reusable day-status icon helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb89479e00832c9e2e4ee825c770e2