### PR TITLE
Add main task highlighting and applause to My Day

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,15 +9,23 @@ html, body, #__next, :root {
 @keyframes main-task-wow {
   0% {
     transform: scale(0.92) rotate(-1deg);
-    box-shadow: 0 0 0 rgba(217, 119, 6, 0);
+    outline-width: 6px;
+    outline-offset: 6px;
   }
   45% {
-    transform: scale(1.06) rotate(1deg);
-    box-shadow: 0 25px 80px -40px rgba(217, 119, 6, 0.55);
+    transform: scale(1.05) rotate(1deg);
+    outline-width: 3px;
+    outline-offset: 5px;
+  }
+  80% {
+    transform: scale(0.98) rotate(-0.5deg);
+    outline-width: 2.5px;
+    outline-offset: 4.5px;
   }
   100% {
     transform: scale(1);
-    box-shadow: 0 0 0 rgba(217, 119, 6, 0);
+    outline-width: 2px;
+    outline-offset: 4px;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,40 @@
 html, body, #__next, :root {
   height: 100%;
 }
+
+@keyframes main-task-wow {
+  0% {
+    transform: scale(0.92) rotate(-1deg);
+    box-shadow: 0 0 0 rgba(217, 119, 6, 0);
+  }
+  45% {
+    transform: scale(1.06) rotate(1deg);
+    box-shadow: 0 25px 80px -40px rgba(217, 119, 6, 0.55);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(217, 119, 6, 0);
+  }
+}
+
+@keyframes main-task-ripple {
+  0% {
+    transform: translate(-50%, -50%) scale(0.55);
+    opacity: 0.8;
+  }
+  60% {
+    opacity: 0.4;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.3);
+    opacity: 0;
+  }
+}
+
+.animate-main-task-wow {
+  animation: main-task-wow 0.65s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.animate-main-task-ripple {
+  animation: main-task-ripple 0.75s ease-out forwards;
+}

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -28,16 +28,16 @@ export default function TaskCard(props: UseTaskCardProps) {
 
   const priorityClass = priorityColors[task.priority];
   const cardClasses = [
-    'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus:ring transition-all duration-500 ease-out transform-gpu',
+    'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-4 transition-all duration-500 ease-out transform-gpu',
     priorityClass,
     isMainTask
       ? [
-          'bg-amber-50/95 text-gray-900',
-          'ring-[1.5px] ring-amber-200/80 hover:ring-amber-300/70',
-          'ring-offset-2 ring-offset-amber-100/70',
-          'dark:bg-amber-500/15 dark:text-amber-50',
-          'dark:ring-[1.5px] dark:ring-amber-300/60 dark:hover:ring-amber-200/60',
-          'dark:ring-offset-2 dark:ring-offset-amber-500/10',
+          'bg-amber-100 text-gray-900',
+          'border border-amber-200 hover:border-amber-300',
+          'outline outline-2 outline-amber-300 outline-offset-4 hover:outline-amber-400',
+          'dark:bg-amber-500/20 dark:text-amber-50',
+          'dark:border-amber-300/70 dark:hover:border-amber-200/70',
+          'dark:outline-amber-300/70 dark:hover:outline-amber-200/70',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
     isMainTaskEntering ? 'animate-main-task-wow' : '',

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -33,10 +33,10 @@ export default function TaskCard(props: UseTaskCardProps) {
     isMainTask
       ? [
           'bg-amber-100 text-gray-900',
-          'shadow-[0_32px_90px_-48px_rgba(217,119,6,0.95)] hover:shadow-[0_24px_65px_-40px_rgba(217,119,6,0.85)]',
+          'shadow-[0_18px_55px_-32px_rgba(217,119,6,0.55)] hover:shadow-[0_22px_60px_-34px_rgba(217,119,6,0.5)]',
           'ring-2 ring-amber-300/80',
           'dark:bg-amber-500/20 dark:text-amber-50',
-          'dark:shadow-[0_32px_90px_-48px_rgba(253,230,138,0.7)] dark:hover:shadow-[0_24px_65px_-40px_rgba(253,230,138,0.55)]',
+          'dark:shadow-[0_18px_55px_-34px_rgba(253,230,138,0.45)] dark:hover:shadow-[0_22px_60px_-36px_rgba(253,230,138,0.4)]',
           'dark:ring-amber-400/60',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
@@ -120,7 +120,7 @@ export default function TaskCard(props: UseTaskCardProps) {
                   title={t('taskCard.mainTaskTooltip')}
                   className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
                     isMainTask
-                      ? 'bg-amber-200/70 text-amber-700 shadow-[0_0_18px_rgba(217,119,6,0.45)] hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
+                      ? 'bg-amber-200/70 text-amber-700 hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
                       : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
                   }`}
                 >

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -32,12 +32,12 @@ export default function TaskCard(props: UseTaskCardProps) {
     priorityClass,
     isMainTask
       ? [
-          'bg-amber-100 text-gray-900',
-          'shadow-[0_18px_55px_-32px_rgba(217,119,6,0.55)] hover:shadow-[0_22px_60px_-34px_rgba(217,119,6,0.5)]',
-          'ring-2 ring-amber-300/80',
-          'dark:bg-amber-500/20 dark:text-amber-50',
-          'dark:shadow-[0_18px_55px_-34px_rgba(253,230,138,0.45)] dark:hover:shadow-[0_22px_60px_-36px_rgba(253,230,138,0.4)]',
-          'dark:ring-amber-400/60',
+          'bg-amber-50/95 text-gray-900',
+          'ring-[1.5px] ring-amber-200/80 hover:ring-amber-300/70',
+          'ring-offset-2 ring-offset-amber-100/70',
+          'dark:bg-amber-500/15 dark:text-amber-50',
+          'dark:ring-[1.5px] dark:ring-amber-300/60 dark:hover:ring-amber-200/60',
+          'dark:ring-offset-2 dark:ring-offset-amber-500/10',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
     isMainTaskEntering ? 'animate-main-task-wow' : '',
@@ -109,29 +109,15 @@ export default function TaskCard(props: UseTaskCardProps) {
           <span className="mr-2 min-w-0 flex-1">
             <LinkifiedText text={task.title} />
           </span>
-          <div className="flex items-center gap-2">
+          <div
+            className={
+              mode === 'my-day'
+                ? 'flex min-h-[4.5rem] flex-col items-end gap-2 pl-3'
+                : 'flex items-center gap-2'
+            }
+          >
             {mode === 'my-day' ? (
               <>
-                <button
-                  type="button"
-                  onClick={handleToggleMainTask}
-                  aria-pressed={isMainTask}
-                  aria-label={mainTaskLabel}
-                  title={t('taskCard.mainTaskTooltip')}
-                  className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
-                    isMainTask
-                      ? 'bg-amber-200/70 text-amber-700 hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
-                      : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
-                  }`}
-                >
-                  <Star
-                    className={`h-4 w-4 transition-transform duration-300 ease-out ${
-                      isMainTask ? 'scale-[1.25] rotate-3 drop-shadow-sm' : ''
-                    }`}
-                    strokeWidth={isMainTask ? 1.5 : 2}
-                    fill={isMainTask ? 'currentColor' : 'none'}
-                  />
-                </button>
                 {task.dayStatus === 'todo' && (
                   <button
                     onClick={markInProgress}
@@ -162,6 +148,26 @@ export default function TaskCard(props: UseTaskCardProps) {
                     <Trash2 className="h-4 w-4" />
                   </button>
                 )}
+                <button
+                  type="button"
+                  onClick={handleToggleMainTask}
+                  aria-pressed={isMainTask}
+                  aria-label={mainTaskLabel}
+                  title={t('taskCard.mainTaskTooltip')}
+                  className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
+                    isMainTask
+                      ? 'bg-amber-200/60 text-amber-700 hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
+                      : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
+                  }`}
+                >
+                  <Star
+                    className={`h-4 w-4 transition-transform duration-300 ease-out ${
+                      isMainTask ? 'scale-110 rotate-3' : ''
+                    }`}
+                    strokeWidth={isMainTask ? 1.5 : 2}
+                    fill={isMainTask ? 'currentColor' : 'none'}
+                  />
+                </button>
               </>
             ) : (
               task.dayStatus !== 'done' && (

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -23,15 +23,27 @@ export default function TaskCard(props: UseTaskCardProps) {
   const shouldForceShowTimer =
     mode === 'my-day' && task.dayStatus === 'doing' && Boolean(timer?.running);
   const [showTimer, setShowTimer] = useState(() => shouldForceShowTimer);
+  const [isMainTaskEntering, setIsMainTaskEntering] = useState(false);
   const isTimerVisible = showTimer || shouldForceShowTimer;
 
   const priorityClass = priorityColors[task.priority];
   const cardClasses = [
-    'group rounded border-l-4 p-4 cursor-grab focus:outline-none focus:ring transition-all duration-200 ease-out',
+    'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus:ring transition-all duration-500 ease-out transform-gpu',
+    priorityClass,
     isMainTask
-      ? 'border-l-amber-400 bg-gradient-to-r from-amber-100 via-yellow-50 to-white text-gray-900 shadow-xl ring-1 ring-amber-300/60 dark:from-amber-500/20 dark:via-amber-400/15 dark:to-gray-950 dark:text-amber-50 dark:ring-amber-500/40'
-      : `${priorityClass} bg-gray-100 dark:bg-gray-800 hover:shadow-md`,
-  ].join(' ');
+      ? [
+          'bg-amber-100 text-gray-900',
+          'shadow-[0_32px_90px_-48px_rgba(217,119,6,0.95)] hover:shadow-[0_24px_65px_-40px_rgba(217,119,6,0.85)]',
+          'ring-2 ring-amber-300/80',
+          'dark:bg-amber-500/20 dark:text-amber-50',
+          'dark:shadow-[0_32px_90px_-48px_rgba(253,230,138,0.7)] dark:hover:shadow-[0_24px_65px_-40px_rgba(253,230,138,0.55)]',
+          'dark:ring-amber-400/60',
+        ].join(' ')
+      : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
+    isMainTaskEntering ? 'animate-main-task-wow' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   const handleToggleMainTask = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -49,6 +61,21 @@ export default function TaskCard(props: UseTaskCardProps) {
     }
   }, [shouldForceShowTimer]);
 
+  useEffect(() => {
+    if (!isMainTask) {
+      setIsMainTaskEntering(false);
+      return;
+    }
+    setIsMainTaskEntering(true);
+    const timeoutId = window.setTimeout(() => {
+      setIsMainTaskEntering(false);
+    }, 800);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isMainTask]);
+
   const handleToggleTimer = () => {
     if (shouldForceShowTimer) {
       return;
@@ -65,112 +92,118 @@ export default function TaskCard(props: UseTaskCardProps) {
       className={cardClasses}
       data-main-task={isMainTask || undefined}
     >
-      <div
-        className={`flex justify-between ${
-          mode === 'my-day' ? 'items-start' : 'items-center'
-        }`}
-      >
-        <span className="mr-2 min-w-0 flex-1">
-          <LinkifiedText text={task.title} />
-        </span>
+      {isMainTask && (
+        <span
+          aria-hidden
+          className={`pointer-events-none absolute left-1/2 top-1/2 h-[18rem] w-[18rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-300/35 blur-3xl ${
+            isMainTaskEntering ? 'animate-main-task-ripple' : 'opacity-0'
+          }`}
+        />
+      )}
+      <div className="relative z-10">
         <div
-          className={`flex gap-2 ${
+          className={`flex justify-between ${
             mode === 'my-day' ? 'items-start' : 'items-center'
           }`}
         >
-          {mode === 'my-day' ? (
-            <>
-              <button
-                type="button"
-                onClick={handleToggleMainTask}
-                aria-pressed={isMainTask}
-                aria-label={mainTaskLabel}
-                title={t('taskCard.mainTaskTooltip')}
-                className={`rounded-full p-1 transition-colors duration-150 focus-visible:outline-none focus-visible:ring focus-visible:ring-amber-400 ${
-                  isMainTask
-                    ? 'bg-amber-100/80 text-amber-600 hover:text-amber-500 dark:bg-amber-500/20 dark:text-amber-300'
-                    : 'text-gray-400 hover:text-amber-400'
-                }`}
-              >
-                <Star
-                  className={`h-4 w-4 transition-transform ${
-                    isMainTask ? 'scale-110' : ''
-                  }`}
-                  strokeWidth={isMainTask ? 1.5 : 2}
-                  fill={isMainTask ? 'currentColor' : 'none'}
-                />
-              </button>
-              {task.dayStatus === 'todo' && (
+          <span className="mr-2 min-w-0 flex-1">
+            <LinkifiedText text={task.title} />
+          </span>
+          <div className="flex items-center gap-2">
+            {mode === 'my-day' ? (
+              <>
                 <button
-                  onClick={markInProgress}
-                  aria-label={t('taskCard.markInProgress')}
-                  title={t('taskCard.markInProgress')}
-                  className="text-blue-400 hover:text-blue-500"
+                  type="button"
+                  onClick={handleToggleMainTask}
+                  aria-pressed={isMainTask}
+                  aria-label={mainTaskLabel}
+                  title={t('taskCard.mainTaskTooltip')}
+                  className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
+                    isMainTask
+                      ? 'bg-amber-200/70 text-amber-700 shadow-[0_0_18px_rgba(217,119,6,0.45)] hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
+                      : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
+                  }`}
                 >
-                  <Play className="h-4 w-4" />
+                  <Star
+                    className={`h-4 w-4 transition-transform duration-300 ease-out ${
+                      isMainTask ? 'scale-[1.25] rotate-3 drop-shadow-sm' : ''
+                    }`}
+                    strokeWidth={isMainTask ? 1.5 : 2}
+                    fill={isMainTask ? 'currentColor' : 'none'}
+                  />
                 </button>
-              )}
-              {task.dayStatus === 'doing' && (
+                {task.dayStatus === 'todo' && (
+                  <button
+                    onClick={markInProgress}
+                    aria-label={t('taskCard.markInProgress')}
+                    title={t('taskCard.markInProgress')}
+                    className="flex h-8 w-8 items-center justify-center rounded-full text-blue-400 transition-colors duration-150 hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/60 focus-visible:ring-offset-2"
+                  >
+                    <Play className="h-4 w-4" />
+                  </button>
+                )}
+                {task.dayStatus === 'doing' && (
+                  <button
+                    onClick={markDone}
+                    aria-label={t('taskCard.markDone')}
+                    title={t('taskCard.markDone')}
+                    className="flex h-8 w-8 items-center justify-center rounded-full text-green-400 transition-colors duration-150 hover:text-green-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-300/60 focus-visible:ring-offset-2"
+                  >
+                    <Check className="h-4 w-4" />
+                  </button>
+                )}
+                {task.dayStatus === 'done' && (
+                  <button
+                    onClick={deleteTask}
+                    aria-label={t('taskCard.deleteTask')}
+                    title={t('taskCard.deleteTask')}
+                    className="flex h-8 w-8 items-center justify-center rounded-full text-red-400 transition-colors duration-150 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300/60 focus-visible:ring-offset-2"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </>
+            ) : (
+              task.dayStatus !== 'done' && (
                 <button
                   onClick={markDone}
                   aria-label={t('taskCard.markDone')}
                   title={t('taskCard.markDone')}
-                  className="text-green-400 hover:text-green-500"
+                  className="flex h-8 w-8 items-center justify-center rounded-full text-green-400 transition-colors duration-150 hover:text-green-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-300/60 focus-visible:ring-offset-2"
                 >
                   <Check className="h-4 w-4" />
                 </button>
-              )}
-              {task.dayStatus === 'done' && (
-                <button
-                  onClick={deleteTask}
-                  aria-label={t('taskCard.deleteTask')}
-                  title={t('taskCard.deleteTask')}
-                  className="text-red-400 hover:text-red-500"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              )}
-            </>
-          ) : (
-            task.dayStatus !== 'done' && (
-              <button
-                onClick={markDone}
-                aria-label={t('taskCard.markDone')}
-                title={t('taskCard.markDone')}
-                className="text-green-400 hover:text-green-500"
-              >
-                <Check className="h-4 w-4" />
-              </button>
-            )
-          )}
+              )
+            )}
+          </div>
         </div>
+        <div className="mt-4 flex flex-wrap gap-1">
+          {task.tags?.map(tag => (
+            <span
+              key={tag}
+              style={{ backgroundColor: getTagColor(tag) }}
+              className="rounded-full px-2 py-1 text-xs text-white"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+        {mode === 'my-day' && task.dayStatus === 'doing' && (
+          <>
+            <Link
+              onClick={handleToggleTimer}
+              aria-label={t('taskCard.showTimer')}
+              title={t('taskCard.showTimer')}
+              icon={Clock}
+              className="mt-4"
+              aria-expanded={isTimerVisible}
+            >
+              {t('taskCard.showTimer')}
+            </Link>
+            {isTimerVisible && <Timer taskId={task.id} />}
+          </>
+        )}
       </div>
-      <div className="mt-4 flex flex-wrap gap-1">
-        {task.tags?.map(tag => (
-          <span
-            key={tag}
-            style={{ backgroundColor: getTagColor(tag) }}
-            className="rounded-full px-2 py-1 text-xs text-white"
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
-      {mode === 'my-day' && task.dayStatus === 'doing' && (
-        <>
-          <Link
-            onClick={handleToggleTimer}
-            aria-label={t('taskCard.showTimer')}
-            title={t('taskCard.showTimer')}
-            icon={Clock}
-            className="mt-4"
-            aria-expanded={isTimerVisible}
-          >
-            {t('taskCard.showTimer')}
-          </Link>
-          {isTimerVisible && <Timer taskId={task.id} />}
-        </>
-      )}
     </div>
   );
 }

--- a/components/TaskCard/useTaskCard.ts
+++ b/components/TaskCard/useTaskCard.ts
@@ -5,6 +5,7 @@ import { Task } from '../../lib/types';
 import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
 import confetti from 'canvas-confetti';
+import { playApplause } from '../../lib/sounds';
 
 export interface UseTaskCardProps {
   task: Task;
@@ -27,7 +28,19 @@ export default function useTaskCard({
         transform: CSS.Transform.toString(transform),
         transition,
       };
-  const { moveTask, removeTask, tags: allTags } = useStore();
+  const {
+    moveTask,
+    removeTask,
+    tags: allTags,
+    mainMyDayTaskId,
+    setMainMyDayTask,
+  } = useStore(state => ({
+    moveTask: state.moveTask,
+    removeTask: state.removeTask,
+    tags: state.tags,
+    mainMyDayTaskId: state.mainMyDayTaskId,
+    setMainMyDayTask: state.setMainMyDayTask,
+  }));
   const { t } = useI18n();
 
   const markInProgress = () => {
@@ -40,6 +53,9 @@ export default function useTaskCard({
     if (task.dayStatus !== 'done') {
       moveTask(task.id, { dayStatus: 'done' });
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+      if (mainMyDayTaskId === task.id) {
+        playApplause();
+      }
     }
   };
 
@@ -52,8 +68,29 @@ export default function useTaskCard({
     return tag ? tag.color : '#ccc';
   };
 
+  const toggleMainTask = () => {
+    if (!task.plannedFor) {
+      return;
+    }
+    setMainMyDayTask(mainMyDayTaskId === task.id ? null : task.id);
+  };
+
   return {
-    state: { attributes, listeners, setNodeRef, style, t, allTags },
-    actions: { markInProgress, markDone, getTagColor, deleteTask },
+    state: {
+      attributes,
+      listeners,
+      setNodeRef,
+      style,
+      t,
+      allTags,
+      isMainTask: mainMyDayTaskId === task.id,
+    },
+    actions: {
+      markInProgress,
+      markDone,
+      getTagColor,
+      deleteTask,
+      toggleMainTask,
+    },
   } as const;
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -59,6 +59,9 @@ const translations: Record<Language, any> = {
       markDone: 'Mark as done',
       deleteTask: 'Delete task',
       showTimer: 'Plan time',
+      setMainTask: 'Mark as main task',
+      unsetMainTask: 'Remove main task status',
+      mainTaskTooltip: 'Main task of the day',
     },
     taskItem: {
       removeMyDay: 'Remove from My Day',
@@ -331,6 +334,9 @@ const translations: Record<Language, any> = {
       markDone: 'Marcar como completada',
       deleteTask: 'Eliminar tarea',
       showTimer: 'Planificar tiempo',
+      setMainTask: 'Marcar como tarea principal',
+      unsetMainTask: 'Quitar tarea principal',
+      mainTaskTooltip: 'Tarea principal del día',
     },
     taskItem: {
       removeMyDay: 'Quitar de Mi Día',

--- a/lib/sounds.ts
+++ b/lib/sounds.ts
@@ -1,0 +1,97 @@
+export function playApplause() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+  if (!AudioCtx) {
+    return;
+  }
+  if (!applauseContext || applauseContext.state === 'closed') {
+    applauseContext = new AudioCtx();
+  }
+  const ctx = applauseContext;
+  if (ctx.state === 'suspended') {
+    ctx.resume().catch(() => {
+      /* noop */
+    });
+  }
+  const buffer = createApplauseBuffer(ctx);
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'bandpass';
+  filter.frequency.value = 1800;
+  filter.Q.value = 0.9;
+  const gain = ctx.createGain();
+  gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.5, ctx.currentTime + 0.06);
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 1.8);
+  const panner = 'createStereoPanner' in ctx ? ctx.createStereoPanner() : null;
+  source.connect(filter);
+  filter.connect(panner ?? gain);
+  if (panner) {
+    panner.pan.value = 0;
+    panner.connect(gain);
+  }
+  gain.connect(ctx.destination);
+  source.start();
+  source.stop(ctx.currentTime + 1.9);
+}
+
+let applauseContext: AudioContext | null = null;
+
+function createApplauseBuffer(ctx: AudioContext) {
+  const duration = 1.9;
+  const sampleRate = ctx.sampleRate;
+  const totalSamples = Math.floor(sampleRate * duration);
+  const buffer = ctx.createBuffer(2, totalSamples, sampleRate);
+
+  for (
+    let channelIndex = 0;
+    channelIndex < buffer.numberOfChannels;
+    channelIndex++
+  ) {
+    const data = buffer.getChannelData(channelIndex);
+    const crowdColor = channelIndex === 0 ? 0.025 : 0.03;
+    for (let i = 0; i < totalSamples; i++) {
+      const progress = i / totalSamples;
+      const fade = Math.pow(1 - progress, 1.3);
+      data[i] = (Math.random() * 2 - 1) * crowdColor * fade;
+    }
+
+    const clapCount = 48;
+    for (let clap = 0; clap < clapCount; clap++) {
+      const start = Math.random() * (duration - 0.18);
+      const width = 0.08 + Math.random() * 0.12;
+      const strength = 0.35 + Math.random() * 0.55;
+      const startIndex = Math.floor(start * sampleRate);
+      const endIndex = Math.min(
+        totalSamples,
+        startIndex + Math.floor(width * sampleRate)
+      );
+      for (let i = startIndex; i < endIndex; i++) {
+        const localProgress =
+          (i - startIndex) / Math.max(1, endIndex - startIndex);
+        const envelope = Math.sin(localProgress * Math.PI) ** 2;
+        const jitter = 0.7 + Math.random() * 0.6;
+        data[i] += (Math.random() * 2 - 1) * envelope * strength * jitter;
+      }
+    }
+
+    let max = 0;
+    for (let i = 0; i < totalSamples; i++) {
+      const abs = Math.abs(data[i]);
+      if (abs > max) {
+        max = abs;
+      }
+    }
+    if (max > 1) {
+      const inv = 1 / max;
+      for (let i = 0; i < totalSamples; i++) {
+        data[i] *= inv;
+      }
+    }
+  }
+
+  return buffer;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,6 +55,7 @@ export type PersistedState = {
   order: Record<string, string[]>;
   notifications: Notification[];
   timers: Record<string, TaskTimer>;
+  mainMyDayTaskId: string | null;
   workSchedule: WorkSchedule;
   workPreferences: WorkPreferences;
   version: number;


### PR DESCRIPTION
## Summary
- allow selecting a single main task in My Day with a star toggle and emphasize its styling
- store and persist the selected main task so it can be reassigned and cleared when needed
- celebrate completing the main task with an applause sound in addition to the existing confetti
- extend translations and tests to cover the new interaction

## Testing
- npm run lint
- npm run test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cb98a6c7c4832c8185ec841c87772c