### PR TITLE
Use notifications for task timer completion

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -190,21 +190,22 @@ export default function Header() {
               className="relative rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
               onClick={() => setShowNotificationPopover(false)}
             >
-              <Bell className="h-4 w-4" />
-              {unreadNotifications > 0 && (
-                <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
-                  {unreadNotifications}
-                </span>
-              )}
+              <span className="relative inline-flex">
+                <Bell className="h-4 w-4" />
+                {unreadNotifications > 0 && (
+                  <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
+                    {unreadNotifications}
+                  </span>
+                )}
+              </span>
             </Link>
             {showNotificationPopover && latestUnreadNotification && (
               <Link
                 href="/notifications"
                 onClick={() => setShowNotificationPopover(false)}
-                className="absolute right-0 top-[calc(100%+0.5rem)] w-64 rounded-md border border-gray-200 bg-white p-3 shadow-lg transition-opacity hover:border-gray-300 focus:border-gray-300 dark:border-gray-700 dark:bg-gray-900"
+                className="absolute right-0 top-full z-20 w-64 border border-gray-200 bg-white px-4 py-3 shadow-lg transition-opacity hover:border-gray-300 focus:border-gray-300 dark:border-gray-700 dark:bg-gray-900"
               >
-                <span className="pointer-events-none absolute -top-1 right-6 block h-3 w-3 rotate-45 border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" />
-                <div className="flex items-start gap-2">
+                <div className="flex items-start gap-3">
                   <NotificationIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
                   <div className="min-w-0">
                     <p className="text-xs font-semibold">{popoverTitle}</p>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -193,7 +193,7 @@ export default function Header() {
               <span className="relative inline-flex">
                 <Bell className="h-4 w-4" />
                 {unreadNotifications > 0 && (
-                  <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
+                  <span className="absolute -right-1 -top-2 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
                     {unreadNotifications}
                   </span>
                 )}
@@ -203,7 +203,7 @@ export default function Header() {
               <Link
                 href="/notifications"
                 onClick={() => setShowNotificationPopover(false)}
-                className="absolute right-0 top-full z-20 w-64 border border-gray-200 bg-white px-4 py-3 shadow-lg transition-opacity hover:border-gray-300 focus:border-gray-300 dark:border-gray-700 dark:bg-gray-900"
+                className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-64 border border-gray-200 bg-white px-4 py-3 shadow-lg transition-opacity hover:border-gray-300 focus:border-gray-300 dark:border-gray-700 dark:bg-gray-900 md:top-[calc(100%+0.75rem)] lg:top-[calc(100%+1rem)]"
               >
                 <div className="flex items-start gap-3">
                   <NotificationIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -190,14 +190,12 @@ export default function Header() {
               className="relative rounded p-2 hover:bg-gray-200 focus:bg-gray-200 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
               onClick={() => setShowNotificationPopover(false)}
             >
-              <span className="relative inline-flex">
-                <Bell className="h-4 w-4" />
-                {unreadNotifications > 0 && (
-                  <span className="absolute -right-1 -top-2 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
-                    {unreadNotifications}
-                  </span>
-                )}
-              </span>
+              <Bell className="h-4 w-4" />
+              {unreadNotifications > 0 && (
+                <span className="absolute -right-1 -top-1 min-w-[16px] rounded-full bg-red-500 px-1 text-center text-[10px] leading-4 text-white">
+                  {unreadNotifications}
+                </span>
+              )}
             </Link>
             {showNotificationPopover && latestUnreadNotification && (
               <Link

--- a/components/Header/useHeader.ts
+++ b/components/Header/useHeader.ts
@@ -66,6 +66,7 @@ export default function useHeader() {
       language,
       myDayCount,
       unreadNotifications,
+      notifications,
     },
     actions: {
       exportData,

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -16,16 +16,17 @@ export default function NotificationCard({ notification }: Props) {
       : notification.type === 'tip'
         ? Lightbulb
         : Info;
+  const title = notification.title ?? t(notification.titleKey);
+  const description =
+    notification.description ?? t(notification.descriptionKey);
 
   return (
     <div className="rounded border border-gray-200 p-6 dark:border-gray-700">
       <div className="flex items-start gap-4">
         <Icon className="mt-1 h-6 w-6 flex-shrink-0" />
         <div className="flex-1">
-          <h2 className="text-lg font-semibold">{t(notification.titleKey)}</h2>
-          <p className="text-base mt-1 w-full">
-            {t(notification.descriptionKey)}
-          </p>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <p className="mt-1 w-full text-base">{description}</p>
           {notification.actionUrl && notification.actionLabelKey && (
             <a
               href={notification.actionUrl}

--- a/components/TaskTimerManager/TaskTimerManager.tsx
+++ b/components/TaskTimerManager/TaskTimerManager.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect } from 'react';
-import { toast } from 'react-hot-toast';
 import { useI18n } from '../../lib/i18n';
 import { useStore } from '../../lib/store';
 
@@ -76,12 +75,24 @@ export default function TaskTimerManager() {
         if (remaining <= 0) {
           state.completeTimer(taskId);
           const task = state.tasks.find(t => t.id === taskId);
-          toast.success(
-            t('timer.finished').replace('{task}', task?.title ?? ''),
-            {
-              duration: 10000,
-            }
-          );
+          const taskTitle = task?.title?.trim()
+            ? task.title
+            : t('notifications.timerFinished.untitledTask');
+          const description = t('timer.finished').replace('{task}', taskTitle);
+          const randomId =
+            typeof globalThis.crypto?.randomUUID === 'function'
+              ? globalThis.crypto.randomUUID()
+              : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+          state.addNotification({
+            id: `timer-finished-${taskId}-${randomId}`,
+            type: 'alert',
+            titleKey: 'notifications.timerFinished.title',
+            descriptionKey: 'notifications.timerFinished.description',
+            title: t('notifications.timerFinished.title'),
+            description,
+            read: false,
+            createdAt: new Date().toISOString(),
+          });
           playSound();
         } else if (remaining !== timer.remaining) {
           state.updateTimerRemaining(taskId, remaining);

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -111,6 +111,11 @@ const translations: Record<Language, any> = {
         description:
           'Your workday is about to finish. Review your progress and decide what comes next.',
       },
+      timerFinished: {
+        title: 'Planned time finished',
+        description: 'A planned time has finished.',
+        untitledTask: 'Untitled task',
+      },
     },
     workSchedulePage: {
       title: 'Work schedule',
@@ -382,6 +387,11 @@ const translations: Record<Language, any> = {
         title: 'Planifica el mañana',
         description:
           'Tu jornada está a punto de terminar. Revisa tu progreso y decide los siguientes pasos.',
+      },
+      timerFinished: {
+        title: 'Tiempo planificado finalizado',
+        description: 'Un tiempo planificado ha finalizado.',
+        untitledTask: 'Tarea sin título',
       },
     },
     workSchedulePage: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -65,6 +65,8 @@ export type Notification = {
   type: 'info' | 'tip' | 'alert';
   titleKey: string;
   descriptionKey: string;
+  title?: string;
+  description?: string;
   read: boolean;
   createdAt: string;
   actionUrl?: string;


### PR DESCRIPTION
## Summary
- route task timer completion events through the notification system with dynamic titles and descriptions
- surface a header popover for unread alerts while supporting custom notification text rendering
- add English and Spanish translations for timer-finished notification strings

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccd2ba5d1c832cb60001b423a90738