### PR TITLE
Increase column header spacing in My Day view

### DIFF
--- a/components/Column/Column.tsx
+++ b/components/Column/Column.tsx
@@ -31,7 +31,7 @@ export default function Column({
       ref={setNodeRef}
       className={containerClasses}
     >
-      <h2 className="mb-2 flex items-center gap-2 text-lg font-semibold">
+      <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
         {StatusIcon ? (
           <StatusIcon
             aria-hidden="true"

--- a/components/Column/Column.tsx
+++ b/components/Column/Column.tsx
@@ -31,7 +31,7 @@ export default function Column({
       ref={setNodeRef}
       className={containerClasses}
     >
-      <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+      <h2 className="mb-6 flex items-center gap-2 text-lg font-semibold">
         {StatusIcon ? (
           <StatusIcon
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- increase the bottom margin on column headers so task lists breathe more

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd49c0048832ca758b0bba9d7de74