### PR TITLE
Fix priority dropdown order

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -172,9 +172,9 @@ export default function AddTask(props: UseAddTaskProps) {
               onChange={e => setPriority(e.target.value as Priority)}
               className="w-full rounded bg-gray-200 p-2 text-sm focus:ring dark:bg-gray-800 lg:w-auto"
             >
-              <option value="low">{t('priority.low')}</option>
-              <option value="medium">{t('priority.medium')}</option>
               <option value="high">{t('priority.high')}</option>
+              <option value="medium">{t('priority.medium')}</option>
+              <option value="low">{t('priority.low')}</option>
             </select>
           </div>
           <button

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -121,9 +121,9 @@ export default function TaskItem({
           className="rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700 flex-1 md:flex-none"
           autoFocus
         >
-          <option value="low">{t('priority.low')}</option>
-          <option value="medium">{t('priority.medium')}</option>
           <option value="high">{t('priority.high')}</option>
+          <option value="medium">{t('priority.medium')}</option>
+          <option value="low">{t('priority.low')}</option>
         </select>
       ) : (
         <button


### PR DESCRIPTION
## Summary
- show "Alta" before "Media" and "Baja" in the add-task priority selector
- align the task item edit selector with the same high-to-low priority order

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd5f05134832caec2de5329284b0a