### PR TITLE
Adjust PWA manifest for fullscreen display

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,9 +3,9 @@
   "short_name": "Quick Planner",
   "description": "Plan your tasks and day locally.",
   "start_url": "/my-tasks",
-  "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "display": "fullscreen",
+  "background_color": "#111827",
+  "theme_color": "#111827",
   "icons": [
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
## Summary
- configure the PWA manifest to launch in fullscreen so the installed app hides browser chrome
- align the manifest theme and background colors with the dark UI palette to avoid a white title bar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cce24b5550832c942d70e7fa2e0047