### PR TITLE
Add weekly recurring tasks support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import WelcomeModal from '../components/WelcomeModal/WelcomeModal';
 import ServiceWorker from '../components/ServiceWorker';
 import TaskTimerManager from '../components/TaskTimerManager/TaskTimerManager';
 import WorkScheduleManager from '../components/WorkScheduleManager/WorkScheduleManager';
+import RecurringTaskManager from '../components/RecurringTaskManager/RecurringTaskManager';
 
 const description =
   'Local Quick Planner is a free, fast, private, and open source task manager that boosts your productivity and personal organization at work.';
@@ -57,6 +58,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <Toaster />
           <TaskTimerManager />
           <WorkScheduleManager />
+          <RecurringTaskManager />
           <WelcomeModal />
           <ServiceWorker />
         </I18nProvider>

--- a/components/RecurringTaskManager/RecurringTaskManager.tsx
+++ b/components/RecurringTaskManager/RecurringTaskManager.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useStore } from '../../lib/store';
+
+const CHECK_INTERVAL = 15 * 60 * 1000;
+
+export default function RecurringTaskManager() {
+  useEffect(() => {
+    const apply = () => {
+      useStore.getState().applyRecurringTasksForToday();
+    };
+
+    apply();
+
+    const interval = window.setInterval(apply, CHECK_INTERVAL);
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        apply();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -6,9 +6,10 @@ import {
   GripVertical,
   Plus,
   HelpCircle,
+  RotateCcw,
 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
-import { Priority, Tag } from '../../lib/types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Priority, Tag, Weekday, WEEKDAYS } from '../../lib/types';
 import { useI18n } from '../../lib/i18n';
 import { getDayStatusIcon } from '../../lib/dayStatus';
 import useTaskItem, { UseTaskItemProps } from './useTaskItem';
@@ -16,6 +17,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
 import Link from '../Link/Link';
+import { useStore } from '../../lib/store';
 
 const BASE_TOOLTIP_OFFSET = -72;
 
@@ -43,12 +45,14 @@ export default function TaskItem({
     saveTitle,
     handleTitleKeyDown,
     updateTask,
+    setTaskRepeat,
     toggleMyDay,
     removeTask,
     toggleTagInput,
   } = actions as any; // when task undefined, actions is empty
   const { t } = useI18n();
   const [isPriorityEditing, setIsPriorityEditing] = useState(false);
+  const [showRecurringOptions, setShowRecurringOptions] = useState(false);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const [tooltipShift, setTooltipShift] = useState(0);
 
@@ -92,6 +96,15 @@ export default function TaskItem({
     high: t('priority.high'),
   };
 
+  const workSchedule = useStore(state => state.workSchedule);
+  const availableWeekdays = useMemo(() => {
+    if (!workSchedule) {
+      return WEEKDAYS;
+    }
+    const active = WEEKDAYS.filter(day => (workSchedule[day] ?? []).length > 0);
+    return active.length > 0 ? active : WEEKDAYS;
+  }, [workSchedule]);
+  const showLimitedWeekdaysHint = availableWeekdays.length < WEEKDAYS.length;
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: taskId, disabled: !task });
   const style = {
@@ -107,96 +120,185 @@ export default function TaskItem({
   const dayStatus = isInMyDay ? (task.dayStatus ?? 'todo') : undefined;
   const StatusIcon = getDayStatusIcon(dayStatus);
   const statusLabel = dayStatus ? t(`board.${dayStatus}`) : null;
+  const weeklyRepeat = task.repeat?.frequency === 'weekly' ? task.repeat : null;
+  const selectedDays = weeklyRepeat ? weeklyRepeat.days : [];
+  const repeatPanelId = `task-repeat-${task.id}`;
+  const repeatButtonLabel = selectedDays.length
+    ? t('taskItem.recurring.buttonWithDays').replace(
+        '{days}',
+        selectedDays
+          .map(day => t(`taskItem.recurring.weekdaysShort.${day}`))
+          .join(', ')
+      )
+    : t('taskItem.recurring.button');
+  const handleToggleRepeatDay = (day: Weekday) => {
+    const nextDays = selectedDays.includes(day)
+      ? selectedDays.filter(d => d !== day)
+      : [...selectedDays, day];
+    setTaskRepeat(task.id, nextDays);
+  };
+  const handleClearRepeat = () => {
+    setTaskRepeat(task.id, []);
+  };
 
   const Actions = ({ showHelp }: { showHelp?: boolean }) => (
-    <>
-      {isPriorityEditing ? (
-        <select
-          value={task.priority ?? ''}
-          onChange={e => {
-            updateTask(task.id, { priority: e.target.value as Priority });
-            setIsPriorityEditing(false);
-          }}
-          onBlur={() => setIsPriorityEditing(false)}
-          className="rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700 flex-1 md:flex-none"
-          autoFocus
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex items-center gap-2">
+        {isPriorityEditing ? (
+          <select
+            value={task.priority ?? ''}
+            onChange={e => {
+              updateTask(task.id, { priority: e.target.value as Priority });
+              setIsPriorityEditing(false);
+            }}
+            onBlur={() => setIsPriorityEditing(false)}
+            className="flex-1 rounded bg-gray-200 p-1 text-sm focus:ring dark:bg-gray-700 md:flex-none"
+            autoFocus
+          >
+            <option value="high">{t('priority.high')}</option>
+            <option value="medium">{t('priority.medium')}</option>
+            <option value="low">{t('priority.low')}</option>
+          </select>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsPriorityEditing(true)}
+            onFocus={() => setIsPriorityEditing(true)}
+            className="flex flex-1 cursor-pointer items-center rounded bg-transparent p-1 text-sm focus:ring dark:text-white md:flex-none"
+          >
+            <span>{priorityLabels[task.priority as Priority]}</span>
+          </button>
+        )}
+        <div className="relative flex items-center">
+          <button
+            onClick={() => toggleMyDay(task.id)}
+            aria-label={
+              task.plannedFor
+                ? t('taskItem.removeMyDay')
+                : t('taskItem.addMyDay')
+            }
+            title={
+              task.plannedFor
+                ? t('taskItem.removeMyDay')
+                : t('taskItem.addMyDay')
+            }
+            className={`rounded bg-transparent p-1 text-black focus:ring dark:text-white ${
+              showHelp
+                ? 'ring-2 ring-[#57886C] ring-offset-2 ring-offset-gray-100 animate-pulse dark:ring-offset-gray-900'
+                : ''
+            }`}
+          >
+            {task.plannedFor ? (
+              <CalendarX className="h-4 w-4" />
+            ) : (
+              <CalendarPlus className="h-4 w-4" />
+            )}
+          </button>
+          {showHelp && (
+            <div
+              ref={tooltipRef}
+              className="absolute top-full left-1/2 z-30 mt-3 w-64 rounded-lg border border-white bg-gray-900 px-3 py-2 text-xs text-white shadow-lg"
+              style={{
+                transform: `translateX(calc(-50% + ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
+              }}
+            >
+              <div className="flex items-start gap-2">
+                <HelpCircle className="mt-[2px] h-4 w-4 flex-shrink-0" />
+                <span className="flex-1 leading-snug">
+                  {t('taskItem.myDayHelp')}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onCloseMyDayHelp?.()}
+                  aria-label={t('actions.close')}
+                  className="ml-2 text-white transition hover:opacity-80"
+                >
+                  ×
+                </button>
+              </div>
+              <span
+                aria-hidden="true"
+                className="absolute left-1/2 bottom-full border-[6px] border-transparent border-b-gray-900"
+                style={{
+                  transform: `translateX(calc(-50% - ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
+                }}
+              />
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => removeTask(task.id)}
+          aria-label={t('taskItem.deleteTask')}
+          title={t('taskItem.deleteTask')}
+          className="rounded bg-transparent p-1 text-black focus:ring dark:text-white"
         >
-          <option value="high">{t('priority.high')}</option>
-          <option value="medium">{t('priority.medium')}</option>
-          <option value="low">{t('priority.low')}</option>
-        </select>
-      ) : (
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+      <div>
         <button
           type="button"
-          onClick={() => setIsPriorityEditing(true)}
-          onFocus={() => setIsPriorityEditing(true)}
-          className="flex items-center rounded bg-transparent p-1 text-sm focus:ring dark:text-white cursor-pointer flex-1 md:flex-none"
+          onClick={() => setShowRecurringOptions(prev => !prev)}
+          aria-expanded={showRecurringOptions}
+          aria-controls={repeatPanelId}
+          title={repeatButtonLabel}
+          className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-[#57886C] transition hover:underline focus-visible:ring focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-gray-100 dark:focus-visible:ring-offset-gray-900"
         >
-          <span>{priorityLabels[task.priority as Priority]}</span>
+          <RotateCcw className="h-3.5 w-3.5" />
+          <span className="flex-1 truncate">{repeatButtonLabel}</span>
         </button>
-      )}
-      <div className="relative flex items-center">
-        <button
-          onClick={() => toggleMyDay(task.id)}
-          aria-label={
-            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-          }
-          title={
-            task.plannedFor ? t('taskItem.removeMyDay') : t('taskItem.addMyDay')
-          }
-          className={`rounded bg-transparent p-1 text-black focus:ring dark:text-white ${
-            showHelp
-              ? 'ring-2 ring-[#57886C] ring-offset-2 ring-offset-gray-100 animate-pulse dark:ring-offset-gray-900'
-              : ''
-          }`}
-        >
-          {task.plannedFor ? (
-            <CalendarX className="h-4 w-4" />
-          ) : (
-            <CalendarPlus className="h-4 w-4" />
-          )}
-        </button>
-        {showHelp && (
+        {showRecurringOptions && (
           <div
-            ref={tooltipRef}
-            className="absolute top-full left-1/2 z-30 mt-3 w-64 rounded-lg border border-white bg-gray-900 px-3 py-2 text-xs text-white shadow-lg"
-            style={{
-              transform: `translateX(calc(-50% + ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
-            }}
+            id={repeatPanelId}
+            className="mt-2 space-y-3 rounded border border-gray-300 bg-white p-3 text-xs text-gray-700 shadow-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
           >
-            <div className="flex items-start gap-2">
-              <HelpCircle className="mt-[2px] h-4 w-4 flex-shrink-0" />
-              <span className="flex-1 leading-snug">
-                {t('taskItem.myDayHelp')}
-              </span>
+            <div className="space-y-1">
+              <p>{t('taskItem.recurring.description')}</p>
+              {showLimitedWeekdaysHint && (
+                <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                  {t('taskItem.recurring.limitedBySchedule')}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {availableWeekdays.map(day => {
+                const checked = selectedDays.includes(day);
+                return (
+                  <label
+                    key={day}
+                    className={`flex items-center gap-2 rounded border px-2 py-1 text-[11px] font-medium ${
+                      checked
+                        ? 'border-[#57886C] text-[#57886C] dark:border-[#78a48c]'
+                        : 'border-gray-200 text-gray-700 dark:border-gray-600 dark:text-gray-200'
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => handleToggleRepeatDay(day)}
+                      className="h-3.5 w-3.5"
+                    />
+                    <span>{t(`workSchedulePage.week.${day}`)}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <p className="text-[11px] text-gray-500 dark:text-gray-400">
+              {t('taskItem.recurring.autoAddHint')}
+            </p>
+            {selectedDays.length > 0 && (
               <button
                 type="button"
-                onClick={() => onCloseMyDayHelp?.()}
-                aria-label={t('actions.close')}
-                className="ml-2 text-white transition hover:opacity-80"
+                onClick={handleClearRepeat}
+                className="text-left text-xs text-red-600 transition hover:underline focus-visible:ring focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-red-400 dark:focus-visible:ring-offset-gray-900"
               >
-                ×
+                {t('taskItem.recurring.remove')}
               </button>
-            </div>
-            <span
-              aria-hidden="true"
-              className="absolute left-1/2 bottom-full border-[6px] border-transparent border-b-gray-900"
-              style={{
-                transform: `translateX(calc(-50% - ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
-              }}
-            />
+            )}
           </div>
         )}
       </div>
-      <button
-        onClick={() => removeTask(task.id)}
-        aria-label={t('taskItem.deleteTask')}
-        title={t('taskItem.deleteTask')}
-        className="rounded bg-transparent p-1 text-black focus:ring dark:text-white"
-      >
-        <Trash2 className="h-4 w-4" />
-      </button>
-    </>
+    </div>
   );
 
   return (
@@ -265,7 +367,7 @@ export default function TaskItem({
                 <LinkifiedText text={task.title} />
               </p>
             )}
-            <div className="hidden md:flex items-center gap-2 md:self-start">
+            <div className="hidden md:flex md:flex-col md:items-stretch md:gap-2 md:self-start">
               <Actions showHelp={showMyDayHelp} />
             </div>
           </div>
@@ -331,7 +433,7 @@ export default function TaskItem({
               </Link>
             )}
           </div>
-          <div className="flex items-center gap-2 md:hidden">
+          <div className="flex flex-col gap-2 md:hidden">
             <Actions showHelp={showMyDayHelp} />
           </div>
         </div>

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -121,7 +121,7 @@ export default function TaskItem({
   const StatusIcon = getDayStatusIcon(dayStatus);
   const statusLabel = dayStatus ? t(`board.${dayStatus}`) : null;
   const weeklyRepeat = task.repeat?.frequency === 'weekly' ? task.repeat : null;
-  const selectedDays = weeklyRepeat ? weeklyRepeat.days : [];
+  const selectedDays: Weekday[] = weeklyRepeat ? weeklyRepeat.days : [];
   const repeatPanelId = `task-repeat-${task.id}`;
   const repeatButtonLabel = selectedDays.length
     ? t('taskItem.recurring.buttonWithDays').replace(

--- a/components/TaskItem/__tests__/TaskItem.test.tsx
+++ b/components/TaskItem/__tests__/TaskItem.test.tsx
@@ -38,6 +38,7 @@ describe('TaskItem', () => {
       },
       actions: {
         startEditing,
+        setTaskRepeat: jest.fn(),
       },
     } as any);
     render(<TaskItem taskId="1" />);

--- a/components/TaskItem/useTaskItem.ts
+++ b/components/TaskItem/useTaskItem.ts
@@ -11,6 +11,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
   const {
     tasks,
     updateTask,
+    setTaskRepeat,
     tags: allTags,
     addTag,
     toggleMyDay,
@@ -115,6 +116,7 @@ export default function useTaskItem({ taskId }: UseTaskItemProps) {
       saveTitle,
       handleTitleKeyDown,
       updateTask,
+      setTaskRepeat,
       toggleMyDay,
       removeTask,
       toggleTagInput,

--- a/lib/__tests__/recurringTasks.test.ts
+++ b/lib/__tests__/recurringTasks.test.ts
@@ -1,0 +1,175 @@
+import { DEFAULT_TIMER_DURATION, useStore } from '../store';
+
+describe('recurring tasks manager', () => {
+  beforeEach(() => {
+    useStore.setState(state => ({
+      ...state,
+      tasks: [],
+      order: {
+        ...state.order,
+        'day-todo': [],
+        'day-doing': [],
+        'day-done': [],
+      },
+      timers: {},
+      mainMyDayTaskId: null,
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    useStore.setState(state => ({
+      ...state,
+      tasks: [],
+      order: {
+        ...state.order,
+        'day-todo': [],
+        'day-doing': [],
+        'day-done': [],
+      },
+      timers: {},
+      mainMyDayTaskId: null,
+    }));
+  });
+
+  it('adds weekly tasks to My Day on the configured weekday', () => {
+    jest.useFakeTimers({ now: new Date('2024-05-20T09:00:00.000Z') });
+    const todayKey = '2024-05-20';
+
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Weekly planning',
+          createdAt: '2024-05-19T10:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: null,
+          tags: [],
+          priority: 'medium',
+          repeat: {
+            frequency: 'weekly',
+            days: ['monday'],
+            autoAddToMyDay: true,
+            lastOccurrenceDate: null,
+          },
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-todo': [],
+        'day-doing': [],
+        'day-done': [],
+      },
+      timers: {},
+    }));
+
+    useStore.getState().applyRecurringTasksForToday();
+
+    const state = useStore.getState();
+    const task = state.tasks[0];
+
+    expect(task.plannedFor).toBe(todayKey);
+    expect(task.dayStatus).toBe('todo');
+    expect(task.repeat?.lastOccurrenceDate).toBe(todayKey);
+    expect(state.order['day-todo']).toEqual(['task-1']);
+    expect(state.timers['task-1']).toMatchObject({
+      duration: DEFAULT_TIMER_DURATION,
+      remaining: DEFAULT_TIMER_DURATION,
+      running: false,
+    });
+  });
+
+  it('does not re-add a task that already ran for today', () => {
+    jest.useFakeTimers({ now: new Date('2024-05-20T09:00:00.000Z') });
+    const todayKey = '2024-05-20';
+
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-2',
+          title: 'Weekly review',
+          createdAt: '2024-05-18T10:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: todayKey,
+          dayStatus: 'todo',
+          tags: [],
+          priority: 'high',
+          repeat: {
+            frequency: 'weekly',
+            days: ['monday'],
+            autoAddToMyDay: true,
+            lastOccurrenceDate: todayKey,
+          },
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-todo': ['task-2'],
+        'day-doing': [],
+        'day-done': [],
+      },
+      timers: {},
+    }));
+
+    // simulate user removing it from My Day
+    useStore.getState().toggleMyDay('task-2');
+
+    const removedState = useStore.getState();
+    expect(removedState.tasks[0].plannedFor).toBeNull();
+
+    useStore.getState().applyRecurringTasksForToday();
+
+    const state = useStore.getState();
+    const task = state.tasks[0];
+
+    expect(task.plannedFor).toBeNull();
+    expect(task.repeat?.lastOccurrenceDate).toBe(todayKey);
+    expect(state.order['day-todo']).not.toContain('task-2');
+  });
+
+  it('respects tasks already in My Day and only updates the last occurrence', () => {
+    jest.useFakeTimers({ now: new Date('2024-05-20T09:00:00.000Z') });
+    const todayKey = '2024-05-20';
+
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-3',
+          title: 'Weekly sync',
+          createdAt: '2024-05-18T10:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: todayKey,
+          dayStatus: 'doing',
+          tags: [],
+          priority: 'medium',
+          repeat: {
+            frequency: 'weekly',
+            days: ['monday'],
+            autoAddToMyDay: true,
+            lastOccurrenceDate: null,
+          },
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-todo': [],
+        'day-doing': ['task-3'],
+        'day-done': [],
+      },
+      timers: {},
+    }));
+
+    useStore.getState().applyRecurringTasksForToday();
+
+    const state = useStore.getState();
+    const task = state.tasks[0];
+
+    expect(task.dayStatus).toBe('doing');
+    expect(task.repeat?.lastOccurrenceDate).toBe(todayKey);
+    expect(state.order['day-doing']).toEqual(['task-3']);
+    expect(state.order['day-todo']).toEqual([]);
+  });
+});

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -69,6 +69,25 @@ const translations: Record<Language, any> = {
       deleteTask: 'Delete task',
       tagPlaceholder: 'Add tag',
       myDayHelp: 'Plan your daily work by adding tasks to My Day.',
+      recurring: {
+        button: 'Repeat every week',
+        buttonWithDays: 'Repeats: {days}',
+        description: 'Select the weekdays when this task should repeat.',
+        limitedBySchedule:
+          'Showing only the days configured in your work schedule.',
+        autoAddHint:
+          'On those days the task will be added to My Day automatically.',
+        remove: 'Remove weekly repetition',
+        weekdaysShort: {
+          monday: 'Mon',
+          tuesday: 'Tue',
+          wednesday: 'Wed',
+          thursday: 'Thu',
+          friday: 'Fri',
+          saturday: 'Sat',
+          sunday: 'Sun',
+        },
+      },
     },
     myDayPage: {
       empty: 'No tasks added to My Day',
@@ -344,6 +363,26 @@ const translations: Record<Language, any> = {
       deleteTask: 'Eliminar tarea',
       tagPlaceholder: 'Añadir etiqueta',
       myDayHelp: 'Planifica tu trabajo diario añadiendo tareas a Mi Día.',
+      recurring: {
+        button: 'Repetir cada semana',
+        buttonWithDays: 'Se repite: {days}',
+        description:
+          'Selecciona los días en los que quieres repetir esta tarea.',
+        limitedBySchedule:
+          'Mostramos solo los días incluidos en tu jornada laboral.',
+        autoAddHint:
+          'Los días seleccionados la tarea se añadirá a Mi Día automáticamente.',
+        remove: 'Quitar repetición semanal',
+        weekdaysShort: {
+          monday: 'L',
+          tuesday: 'M',
+          wednesday: 'X',
+          thursday: 'J',
+          friday: 'V',
+          saturday: 'S',
+          sunday: 'D',
+        },
+      },
     },
     myDayPage: {
       empty: 'No hay tareas añadidas a Mi Día',

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -433,8 +433,8 @@ export const useStore = create<Store>((set, get) => ({
     });
     saveState(get());
   },
-  setTaskRepeat: (id, days) => {
-    const normalizedDays = Array.from(new Set(days)).sort(
+  setTaskRepeat: (id: string, days: Weekday[]) => {
+    const normalizedDays: Weekday[] = Array.from(new Set(days)).sort(
       (a, b) => WEEKDAY_ORDER[a] - WEEKDAY_ORDER[b]
     );
     set(state => {
@@ -450,7 +450,7 @@ export const useStore = create<Store>((set, get) => ({
           changed = true;
           return { ...task, repeat: null };
         }
-        const current =
+        const current: TaskRepeat | null =
           task.repeat?.frequency === 'weekly' ? task.repeat : null;
         const currentDays = current
           ? [...current.days].sort(
@@ -466,14 +466,15 @@ export const useStore = create<Store>((set, get) => ({
         changed = true;
         const lastOccurrenceDate =
           isSameDays && current ? (current.lastOccurrenceDate ?? null) : null;
+        const nextRepeat: TaskRepeat = {
+          frequency: 'weekly',
+          days: [...normalizedDays],
+          autoAddToMyDay: true,
+          lastOccurrenceDate,
+        };
         return {
           ...task,
-          repeat: {
-            frequency: 'weekly',
-            days: [...normalizedDays],
-            autoAddToMyDay: true,
-            lastOccurrenceDate,
-          },
+          repeat: nextRepeat,
         };
       });
       if (!changed) {
@@ -957,7 +958,8 @@ export const useStore = create<Store>((set, get) => ({
         low: 2,
       };
       const tasks = state.tasks.map(task => {
-        const repeat = task.repeat?.frequency === 'weekly' ? task.repeat : null;
+        const repeat: TaskRepeat | null =
+          task.repeat?.frequency === 'weekly' ? task.repeat : null;
         if (!repeat || !repeat.days.includes(weekday)) {
           return task;
         }
@@ -972,7 +974,8 @@ export const useStore = create<Store>((set, get) => ({
         if (alreadyAppliedToday) {
           if (updatedRepeat !== repeat) {
             changed = true;
-            return { ...task, repeat: updatedRepeat };
+            const updatedTask: Task = { ...task, repeat: updatedRepeat };
+            return updatedTask;
           }
           return task;
         }
@@ -984,10 +987,11 @@ export const useStore = create<Store>((set, get) => ({
 
         if (task.plannedFor === todayKey) {
           changed = true;
-          return {
+          const updatedTask: Task = {
             ...task,
             repeat: updatedRepeat,
           };
+          return updatedTask;
         }
 
         changed = true;
@@ -1042,12 +1046,13 @@ export const useStore = create<Store>((set, get) => ({
               endsAt: null,
             };
 
-        return {
+        const updatedTask: Task = {
           ...task,
           plannedFor: todayKey,
           dayStatus: 'todo',
           repeat: updatedRepeat,
         };
+        return updatedTask;
       });
 
       if (!changed) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,32 @@ export type Tag = {
   favorite?: boolean;
 };
 
+export type Weekday =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export const WEEKDAYS: Weekday[] = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+];
+
+export type TaskRepeat = {
+  frequency: 'weekly';
+  days: Weekday[];
+  autoAddToMyDay: boolean;
+  lastOccurrenceDate: string | null;
+};
+
 export type Task = {
   id: string;
   title: string;
@@ -18,6 +44,7 @@ export type Task = {
   listId: string;
   plannedFor: string | null;
   dayStatus?: 'todo' | 'doing' | 'done';
+  repeat?: TaskRepeat | null;
 };
 
 export type List = { id: string; title: string; order: number };
@@ -28,15 +55,6 @@ export type TaskTimer = {
   running: boolean;
   endsAt: string | null;
 };
-
-export type Weekday =
-  | 'monday'
-  | 'tuesday'
-  | 'wednesday'
-  | 'thursday'
-  | 'friday'
-  | 'saturday'
-  | 'sunday';
 
 export type WorkSchedule = Record<Weekday, number[]>;
 


### PR DESCRIPTION
## Summary
- add weekly recurrence controls in the My Tasks view so tasks can be scheduled on specific weekdays
- persist recurring task metadata and automatically enqueue them in My Day via a background manager
- cover the new recurrence workflow with unit tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cce1c81858832caa09565ab21b2c69