### PR TITLE
Add audio cue for planning reminder notification

### DIFF
--- a/components/WorkScheduleManager/WorkScheduleManager.tsx
+++ b/components/WorkScheduleManager/WorkScheduleManager.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-hot-toast';
 import { useI18n } from '../../lib/i18n';
 import { useStore } from '../../lib/store';
 import type { Weekday } from '../../lib/types';
+import { playReminderSound } from '../../lib/sounds';
 
 const DAY_FROM_INDEX: Record<number, Weekday> = {
   0: 'sunday',
@@ -73,6 +74,7 @@ export default function WorkScheduleManager() {
 
         state.setPlanningReminderLastNotified(todayKey);
         toast(t('workSchedulePage.reminder.toast'), { duration: 8000 });
+        playReminderSound();
         const randomId =
           typeof globalThis.crypto?.randomUUID === 'function'
             ? globalThis.crypto.randomUUID()

--- a/components/WorkScheduleManager/__tests__/WorkScheduleManager.test.tsx
+++ b/components/WorkScheduleManager/__tests__/WorkScheduleManager.test.tsx
@@ -1,0 +1,71 @@
+jest.mock('react-hot-toast', () => ({
+  toast: jest.fn(),
+}));
+jest.mock('../../../lib/sounds', () => ({
+  playReminderSound: jest.fn(),
+}));
+
+import { act } from '@testing-library/react';
+import { render } from '../../../test/test-utils';
+import WorkScheduleManager from '../WorkScheduleManager';
+import { useStore } from '../../../lib/store';
+import { toast } from 'react-hot-toast';
+import { playReminderSound } from '../../../lib/sounds';
+
+describe('WorkScheduleManager', () => {
+  const initialState = useStore.getState();
+  const mockedToast = toast as jest.MockedFunction<typeof toast>;
+  const mockedPlayReminderSound = playReminderSound as jest.MockedFunction<
+    typeof playReminderSound
+  >;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-05-01T16:29:30.000Z'));
+    useStore.setState({
+      notifications: [],
+      workSchedule: {
+        ...initialState.workSchedule,
+        wednesday: [30, 31, 32, 33],
+      },
+      workPreferences: {
+        planningReminder: {
+          enabled: true,
+          minutesBefore: 30,
+          lastNotifiedDate: null,
+        },
+      },
+    });
+    mockedToast.mockClear();
+    mockedPlayReminderSound.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    useStore.setState(initialState, true);
+  });
+
+  it('creates an unread notification when the reminder window starts', () => {
+    render(<WorkScheduleManager />);
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    const state = useStore.getState();
+    expect(state.workPreferences.planningReminder.lastNotifiedDate).toBe(
+      '2024-05-01'
+    );
+    expect(state.notifications[0]).toMatchObject({
+      type: 'tip',
+      read: false,
+      titleKey: 'notifications.workReminder.title',
+      descriptionKey: 'notifications.workReminder.description',
+    });
+    expect(mockedToast).toHaveBeenCalledWith(
+      'Your workday is about to end. Take a moment to plan tomorrow.',
+      { duration: 8000 }
+    );
+    expect(mockedPlayReminderSound).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- play a chime when the workday planning reminder fires and enqueue the notification for the header popover
- add a Web Audio helper dedicated to the planning reminder tone
- cover the reminder workflow with a unit test that checks the toast message, sound playback and stored notification

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cce480d18c832cbcf3677d51925609