### PR TITLE
Add option to clear completed tasks from My Day

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -8,6 +8,9 @@ import { useI18n } from '../../lib/i18n';
 export default function MyDayPage() {
   const { t } = useI18n();
   const tasks = useStore(state => state.tasks);
+  const clearCompletedMyDayTasks = useStore(
+    state => state.clearCompletedMyDayTasks
+  );
   const plannedTasks = tasks.filter(task => task.plannedFor !== null);
   const remainingTasks = plannedTasks.filter(task => task.dayStatus !== 'done');
   const progressPercent = plannedTasks.length
@@ -17,6 +20,10 @@ export default function MyDayPage() {
       )
     : 0;
   const hasMyDayTasks = plannedTasks.length > 0;
+  const allTasksCompleted = hasMyDayTasks && remainingTasks.length === 0;
+  const clearCompletedLabel = allTasksCompleted
+    ? t('myDayPage.progress.clearCompleted')
+    : undefined;
 
   return (
     <main
@@ -28,7 +35,13 @@ export default function MyDayPage() {
     >
       {hasMyDayTasks ? (
         <>
-          <ProgressBar percent={progressPercent} />
+          <ProgressBar
+            percent={progressPercent}
+            onClearCompleted={
+              allTasksCompleted ? clearCompletedMyDayTasks : undefined
+            }
+            clearCompletedLabel={clearCompletedLabel}
+          />
           <Board mode="my-day" />
         </>
       ) : (

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -4,13 +4,21 @@ import { useI18n } from '../../lib/i18n';
 
 interface ProgressBarProps {
   percent: number;
+  onClearCompleted?: () => void;
+  clearCompletedLabel?: string;
 }
 
-export default function ProgressBar({ percent }: ProgressBarProps) {
+export default function ProgressBar({
+  percent,
+  onClearCompleted,
+  clearCompletedLabel,
+}: ProgressBarProps) {
   const { t } = useI18n();
 
   let colorClass = 'bg-red-500';
   let message = t('myDayPage.progress.full');
+  const showClearAction =
+    percent >= 100 && onClearCompleted && clearCompletedLabel;
 
   if (percent >= 100) {
     colorClass = 'bg-green-500';
@@ -31,9 +39,18 @@ export default function ProgressBar({ percent }: ProgressBarProps) {
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
-        {message}
-      </p>
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+        <span>{message}</span>
+        {showClearAction ? (
+          <button
+            type="button"
+            onClick={onClearCompleted}
+            className="rounded px-1 font-medium text-[#57886C] underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#57886C]"
+          >
+            {clearCompletedLabel}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/components/ProgressBar/__tests__/ProgressBar.test.tsx
+++ b/components/ProgressBar/__tests__/ProgressBar.test.tsx
@@ -13,8 +13,27 @@ describe('ProgressBar', () => {
   it('shows completion message when percent is 100', () => {
     const { container } = render(<ProgressBar percent={100} />);
     expect(screen.getByText(/all tasks completed/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove completed tasks/i })
+    ).not.toBeInTheDocument();
     const bar = container.querySelector('div[style]') as HTMLElement;
     expect(bar).toHaveClass('bg-green-500');
     expect(bar).toHaveStyle({ width: '100%' });
+  });
+
+  it('renders clear completed action when provided', () => {
+    const onClear = jest.fn();
+    render(
+      <ProgressBar
+        percent={100}
+        onClearCompleted={onClear}
+        clearCompletedLabel="Remove completed tasks"
+      />
+    );
+    const button = screen.getByRole('button', {
+      name: /remove completed tasks/i,
+    });
+    button.click();
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/__tests__/clearCompletedMyDayTasks.test.ts
+++ b/lib/__tests__/clearCompletedMyDayTasks.test.ts
@@ -1,0 +1,155 @@
+import { useStore, DEFAULT_TIMER_DURATION } from '../store';
+
+describe('clearCompletedMyDayTasks', () => {
+  const resetState = () => {
+    useStore.setState(state => ({
+      ...state,
+      tasks: [],
+      order: {
+        ...state.order,
+        'day-todo': [],
+        'day-doing': [],
+        'day-done': [],
+        'priority-high': [],
+        'priority-medium': [],
+        'priority-low': [],
+      },
+      timers: {},
+      mainMyDayTaskId: null,
+    }));
+  };
+
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    resetState();
+  });
+
+  it('removes non recurring completed tasks completely', () => {
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Finish report',
+          createdAt: '2024-06-01T08:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: '2024-06-02',
+          dayStatus: 'done',
+          tags: [],
+          priority: 'medium',
+          repeat: null,
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-done': ['task-1'],
+        'priority-medium': ['task-1'],
+      },
+      timers: {
+        ...state.timers,
+        'task-1': {
+          duration: DEFAULT_TIMER_DURATION,
+          remaining: DEFAULT_TIMER_DURATION,
+          running: false,
+          endsAt: null,
+        },
+      },
+      mainMyDayTaskId: 'task-1',
+    }));
+
+    useStore.getState().clearCompletedMyDayTasks();
+
+    const state = useStore.getState();
+    expect(state.tasks.find(task => task.id === 'task-1')).toBeUndefined();
+    expect(state.order['day-done']).not.toContain('task-1');
+    expect(state.order['priority-medium']).not.toContain('task-1');
+    expect(state.timers['task-1']).toBeUndefined();
+    expect(state.mainMyDayTaskId).toBeNull();
+  });
+
+  it('removes recurring tasks only from My Day', () => {
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-2',
+          title: 'Weekly planning',
+          createdAt: '2024-06-01T08:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: '2024-06-02',
+          dayStatus: 'done',
+          tags: [],
+          priority: 'high',
+          repeat: {
+            frequency: 'weekly',
+            days: ['monday'],
+            autoAddToMyDay: true,
+            lastOccurrenceDate: '2024-06-02',
+          },
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-done': ['task-2'],
+        'priority-high': ['task-2'],
+      },
+      timers: {
+        ...state.timers,
+        'task-2': {
+          duration: DEFAULT_TIMER_DURATION,
+          remaining: 120,
+          running: true,
+          endsAt: '2024-06-02T09:00:00.000Z',
+        },
+      },
+      mainMyDayTaskId: 'task-2',
+    }));
+
+    useStore.getState().clearCompletedMyDayTasks();
+
+    const state = useStore.getState();
+    const task = state.tasks.find(t => t.id === 'task-2');
+    expect(task).toBeDefined();
+    expect(task?.plannedFor).toBeNull();
+    expect(task?.dayStatus).toBeUndefined();
+    expect(task?.repeat?.frequency).toBe('weekly');
+    expect(state.order['day-done']).not.toContain('task-2');
+    expect(state.order['priority-high']).toContain('task-2');
+    expect(state.timers['task-2']).toBeUndefined();
+    expect(state.mainMyDayTaskId).toBeNull();
+  });
+
+  it('ignores tasks that are not completed', () => {
+    useStore.setState(state => ({
+      ...state,
+      tasks: [
+        {
+          id: 'task-3',
+          title: 'Unfinished task',
+          createdAt: '2024-06-01T08:00:00.000Z',
+          listId: 'backlog',
+          plannedFor: '2024-06-02',
+          dayStatus: 'doing',
+          tags: [],
+          priority: 'low',
+          repeat: null,
+        },
+      ],
+      order: {
+        ...state.order,
+        'day-doing': ['task-3'],
+        'priority-low': ['task-3'],
+      },
+    }));
+
+    useStore.getState().clearCompletedMyDayTasks();
+
+    const state = useStore.getState();
+    expect(state.tasks.find(task => task.id === 'task-3')).toBeDefined();
+    expect(state.order['day-doing']).toContain('task-3');
+    expect(state.order['priority-low']).toContain('task-3');
+  });
+});

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -97,6 +97,7 @@ const translations: Record<Language, any> = {
         medium: "You're making progress—keep going!",
         low: 'Almost there—keep it up!',
         done: 'All tasks completed! Great job!',
+        clearCompleted: 'Remove completed tasks',
       },
     },
     timer: {
@@ -397,6 +398,7 @@ const translations: Record<Language, any> = {
         medium: '¡Buen progreso, sigue así!',
         low: '¡Ánimo, ya falta poco!',
         done: '¡Todo hecho, gran trabajo!',
+        clearCompleted: 'Eliminar tareas completadas',
       },
     },
     timer: {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -222,6 +222,7 @@ type Store = PersistedState & {
   ) => void;
   reorderMyTasks: (id: string, newIndex: number) => void;
   toggleMyDay: (id: string) => void;
+  clearCompletedMyDayTasks: () => void;
   setTimerDuration: (id: string, duration: number) => void;
   toggleTimer: (id: string) => void;
   updateTimerRemaining: (id: string, remaining: number) => void;
@@ -697,6 +698,24 @@ export const useStore = create<Store>((set, get) => ({
       };
     });
     saveState(get());
+  },
+  clearCompletedMyDayTasks: () => {
+    const { tasks, toggleMyDay, removeTask } = get();
+    const completedTasks = tasks.filter(
+      task => task.plannedFor && task.dayStatus === 'done'
+    );
+    if (completedTasks.length === 0) {
+      return;
+    }
+    completedTasks.forEach(task => {
+      const repeat =
+        task.repeat?.frequency === 'weekly' && task.repeat.days.length > 0;
+      if (repeat) {
+        toggleMyDay(task.id);
+      } else {
+        removeTask(task.id);
+      }
+    });
   },
   setMainMyDayTask: id => {
     set(state => {


### PR DESCRIPTION
## Summary
- add a store action to clear completed My Day tasks while keeping recurring tasks in My Tasks
- show a clear-completed control next to the My Day progress bar message when everything is done
- cover the new behavior with unit tests and updated translations

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf8fd7c3b0832cbd6dd5c9a9e623cf