### PR TITLE
Adjust spacing for empty My Day state

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -30,7 +30,7 @@ export default function MyDayPage() {
       className={
         hasMyDayTasks
           ? undefined
-          : 'flex flex-col items-center justify-center p-4 text-center'
+          : 'flex flex-col items-center justify-center px-4 py-16 text-center'
       }
     >
       {hasMyDayTasks ? (


### PR DESCRIPTION
## Summary
- increase the vertical padding for the empty My Day view so the message has more space below the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0dc8e48a8832cb0133cf1b7b7a3b4