### PR TITLE
Improve notification card layout and dismissal

### DIFF
--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Info, AlertTriangle, Lightbulb } from 'lucide-react';
+import { Info, AlertTriangle, Lightbulb, X } from 'lucide-react';
 import { useI18n } from '../../lib/i18n';
 import { Notification } from '../../lib/types';
+import { useStore } from '../../lib/store';
 
 interface Props {
   notification: Notification;
@@ -10,6 +11,7 @@ interface Props {
 
 export default function NotificationCard({ notification }: Props) {
   const { t } = useI18n();
+  const removeNotification = useStore(state => state.removeNotification);
   const Icon =
     notification.type === 'alert'
       ? AlertTriangle
@@ -19,20 +21,42 @@ export default function NotificationCard({ notification }: Props) {
   const title = notification.title ?? t(notification.titleKey);
   const description =
     notification.description ?? t(notification.descriptionKey);
+  const dismissLabel = t('notifications.dismiss');
 
   return (
-    <div className="rounded border border-gray-200 p-6 dark:border-gray-700">
+    <div className="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-700/60">
+      <button
+        type="button"
+        aria-label={dismissLabel}
+        title={dismissLabel}
+        onClick={() => removeNotification(notification.id)}
+        className="absolute right-4 top-4 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+      >
+        <X
+          className="h-4 w-4"
+          aria-hidden="true"
+        />
+      </button>
       <div className="flex items-start gap-4">
-        <Icon className="mt-1 h-6 w-6 flex-shrink-0" />
-        <div className="flex-1">
-          <h2 className="text-lg font-semibold">{title}</h2>
-          <p className="mt-1 w-full text-base">{description}</p>
+        <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-300">
+          <Icon
+            className="h-6 w-6"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="flex-1 space-y-3 pr-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {title}
+          </h2>
+          <p className="text-base leading-relaxed text-gray-700 break-words dark:text-gray-200">
+            {description}
+          </p>
           {notification.actionUrl && notification.actionLabelKey && (
             <a
               href={notification.actionUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-3 inline-block rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-500"
+              className="inline-flex max-w-full flex-wrap break-words rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
             >
               {t(notification.actionLabelKey)}
             </a>

--- a/components/NotificationCard/__tests__/NotificationCard.test.tsx
+++ b/components/NotificationCard/__tests__/NotificationCard.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '../../../test/test-utils';
+import userEvent from '@testing-library/user-event';
 import NotificationCard from '../NotificationCard';
+import { useStore } from '../../../lib/store';
 
 const baseNotification = {
   id: 'n1',
@@ -9,6 +11,18 @@ const baseNotification = {
   read: false,
   createdAt: new Date().toISOString(),
 };
+
+const initialState = useStore.getState();
+const removeNotificationMock = jest.fn();
+
+beforeEach(() => {
+  removeNotificationMock.mockReset();
+  useStore.setState({ removeNotification: removeNotificationMock });
+});
+
+afterEach(() => {
+  useStore.setState(initialState, true);
+});
 
 describe('NotificationCard', () => {
   it('renders title and description', () => {
@@ -33,5 +47,18 @@ describe('NotificationCard', () => {
 
     const link = screen.getByRole('link', { name: /more actions/i });
     expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('allows dismissing the notification', async () => {
+    const user = userEvent.setup();
+    render(<NotificationCard notification={baseNotification} />);
+
+    const dismissButton = screen.getByRole('button', {
+      name: /dismiss notification/i,
+    });
+
+    await user.click(dismissButton);
+
+    expect(removeNotificationMock).toHaveBeenCalledWith('n1');
   });
 });

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -124,6 +124,7 @@ const translations: Record<Language, any> = {
     notifications: {
       title: 'Notifications',
       empty: 'No notifications',
+      dismiss: 'Dismiss notification',
       welcome: {
         title: 'Welcome to Local Quick Planner',
         description:
@@ -425,6 +426,7 @@ const translations: Record<Language, any> = {
     notifications: {
       title: 'Notificaciones',
       empty: 'Sin notificaciones',
+      dismiss: 'Cerrar notificación',
       welcome: {
         title: '¡Hola! Te damos la bienvenida a Local Quick Planner',
         description:

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -233,6 +233,7 @@ type Store = PersistedState & {
   importData: (data: PersistedState) => void;
   clearAll: () => void;
   addNotification: (n: Notification) => void;
+  removeNotification: (id: string) => void;
   markNotificationRead: (id: string) => void;
   markAllNotificationsRead: () => void;
   setWorkScheduleDay: (day: Weekday, slots: number[]) => void;
@@ -856,6 +857,12 @@ export const useStore = create<Store>((set, get) => ({
   },
   addNotification: n => {
     set(state => ({ notifications: [n, ...state.notifications] }));
+    saveState(get());
+  },
+  removeNotification: id => {
+    set(state => ({
+      notifications: state.notifications.filter(n => n.id !== id),
+    }));
     saveState(get());
   },
   markNotificationRead: id => {


### PR DESCRIPTION
## Summary
- refresh notification card styling to keep content within the container and add a dismiss button
- add store support and translations for removing notifications from the list
- cover the new dismissal control with unit tests

## Testing
- npm test -- NotificationCard
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a6ef23ec832c8a7209d9a54a922f