### PR TITLE
Improve dark mode scrollbar styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body, #__next, :root {
+html,
+body,
+#__next,
+:root {
   height: 100%;
 }
 
@@ -49,4 +52,36 @@ html, body, #__next, :root {
 
 .animate-main-task-ripple {
   animation: main-task-ripple 0.75s ease-out forwards;
+}
+
+@media (prefers-color-scheme: dark) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.45) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.45);
+    border-radius: 9999px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+    transition: background-color 150ms ease-in-out;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(226, 232, 240, 0.6);
+  }
+
+  *::-webkit-scrollbar-thumb:active {
+    background-color: rgba(226, 232, 240, 0.75);
+  }
 }


### PR DESCRIPTION
## Summary
- restyle the global dark theme scrollbars to be thin, rounded, and softly colored for a macOS-like feel

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d1a879e6dc832c82251e9edfeaed55