### PR TITLE
Fix My Day board scroll container layout

### DIFF
--- a/components/Board/Board.tsx
+++ b/components/Board/Board.tsx
@@ -10,6 +10,11 @@ export default function Board(props: UseBoardProps) {
   const { getTasks, handleDragStart, handleDragOver, handleDragEnd } = actions;
   const { closestCorners } = helpers;
 
+  const scrollContainerClasses =
+    props.mode === 'my-day'
+      ? 'w-full overflow-x-auto overflow-y-visible p-4 touch-pan-x snap-x snap-mandatory lg:overflow-x-visible'
+      : 'w-full overflow-x-auto p-4 touch-pan-x snap-x snap-mandatory';
+
   return (
     <DndContext
       sensors={sensors}
@@ -18,17 +23,19 @@ export default function Board(props: UseBoardProps) {
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex gap-4 overflow-x-auto p-4 touch-pan-x snap-x snap-mandatory">
-        {columns.map(col => (
-          <Column
-            key={col.id}
-            id={col.id}
-            title={col.title}
-            tasks={getTasks(col.id)}
-            mode={props.mode}
-            status={col.status}
-          />
-        ))}
+      <div className={scrollContainerClasses}>
+        <div className="flex w-full min-w-full gap-4">
+          {columns.map(col => (
+            <Column
+              key={col.id}
+              id={col.id}
+              title={col.title}
+              tasks={getTasks(col.id)}
+              mode={props.mode}
+              status={col.status}
+            />
+          ))}
+        </div>
       </div>
       <DragOverlay>
         {activeTask ? (


### PR DESCRIPTION
## Summary
- ensure the My Day board container keeps vertical overflow visible while still allowing horizontal swiping on small screens
- keep horizontal scrolling for smaller screens while letting large screens rely on the global page scrollbar

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d1a77c2fdc832ca6fd1d30b3091ac5