### PR TITLE
fix: sync add task form with favorite tags

### DIFF
--- a/components/AddTask/__tests__/useAddTask.test.tsx
+++ b/components/AddTask/__tests__/useAddTask.test.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { render, waitFor } from '../../../test/test-utils';
+import useAddTask from '../useAddTask';
+import { Priority, Tag } from '../../../lib/types';
+
+type AddTaskInput = {
+  title: string;
+  tags: string[];
+  priority: Priority;
+};
+
+const noopAddTask = (_input: AddTaskInput) => 'new-task';
+const noopAddTag = () => {};
+
+function UseAddTaskTest({
+  tags,
+  onTagsChange,
+}: {
+  tags: Tag[];
+  onTagsChange: (value: string[]) => void;
+}) {
+  const { state } = useAddTask({
+    addTask: noopAddTask,
+    tags,
+    addTag: noopAddTag,
+  });
+
+  useEffect(() => {
+    onTagsChange(state.tags);
+  }, [onTagsChange, state.tags]);
+
+  return null;
+}
+
+describe('useAddTask', () => {
+  it('adds newly favorited tags to the selected tags list', async () => {
+    const initialTags: Tag[] = [
+      { id: '1', label: 'work', color: '#f00', favorite: true },
+      { id: '2', label: 'home', color: '#0f0', favorite: false },
+    ];
+    let latestTags: string[] = [];
+
+    const { rerender } = render(
+      <UseAddTaskTest
+        tags={initialTags}
+        onTagsChange={value => {
+          latestTags = value;
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(latestTags).toEqual(['work']);
+    });
+
+    const updatedTags: Tag[] = [
+      { id: '1', label: 'work', color: '#f00', favorite: true },
+      { id: '2', label: 'home', color: '#0f0', favorite: true },
+    ];
+
+    rerender(
+      <UseAddTaskTest
+        tags={updatedTags}
+        onTagsChange={value => {
+          latestTags = value;
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(latestTags).toEqual(['work', 'home']);
+    });
+  });
+});

--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -26,7 +26,20 @@ export default function useAddTask({
   useEffect(() => {
     setTags(prev => {
       const existingLabels = existingTags.map(t => t.label);
-      return prev.filter(t => existingLabels.includes(t));
+      const favoriteLabels = existingTags
+        .filter(t => t.favorite)
+        .map(t => t.label);
+
+      const filtered = prev.filter(t => existingLabels.includes(t));
+      const withFavorites = [...filtered];
+
+      favoriteLabels.forEach(label => {
+        if (!withFavorites.includes(label)) {
+          withFavorites.push(label);
+        }
+      });
+
+      return withFavorites;
     });
   }, [existingTags]);
 


### PR DESCRIPTION
## Summary
- ensure the AddTask hook keeps its tag selection aligned with favorite tags
- cover the new favorite tag behavior with a dedicated unit test

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npx prettier --check components/AddTask

------
https://chatgpt.com/codex/tasks/task_e_68d1b24b6ab8832cae089514a16223d0