### PR TITLE
Add intro empty state for My Tasks

### DIFF
--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -12,9 +12,16 @@ import NoTasksIllustration from './NoTasksIllustration';
 
 interface TaskListProps extends UseTaskListProps {
   highlightedId?: string | null;
+  hasTasks: boolean;
+  isFiltering: boolean;
 }
 
-export default function TaskList({ tasks, highlightedId }: TaskListProps) {
+export default function TaskList({
+  tasks,
+  highlightedId,
+  hasTasks,
+  isFiltering,
+}: TaskListProps) {
   const { state, actions } = useTaskList({ tasks });
   const { sensors } = state;
   const { handleDragEnd } = actions;
@@ -109,6 +116,8 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
   }, [tasks, showMyDayHelp, myDayHelpTaskId, hideMyDayHelp]);
 
   const { t } = useI18n();
+  const emptyMessageKey =
+    !hasTasks && !isFiltering ? 'taskList.noTasksIntro' : 'taskList.noTasks';
   return (
     <DndContext
       sensors={sensors}
@@ -131,7 +140,7 @@ export default function TaskList({ tasks, highlightedId }: TaskListProps) {
           {tasks.length === 0 && (
             <div className="flex flex-col items-center">
               <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-                {t('taskList.noTasks')}
+                {t(emptyMessageKey)}
               </p>
               <NoTasksIllustration className="mt-4 text-gray-400 dark:text-gray-500" />
             </div>

--- a/components/TaskList/__tests__/TaskList.test.tsx
+++ b/components/TaskList/__tests__/TaskList.test.tsx
@@ -31,13 +31,36 @@ describe('TaskList', () => {
   ];
 
   it('renders tasks', () => {
-    render(<TaskList tasks={tasks} />);
+    render(
+      <TaskList
+        tasks={tasks}
+        hasTasks
+        isFiltering={false}
+      />
+    );
     expect(screen.getByTestId('task-1')).toBeInTheDocument();
     expect(screen.getByTestId('task-2')).toBeInTheDocument();
   });
 
-  it('shows empty message', () => {
-    render(<TaskList tasks={[]} />);
+  it('shows intro empty message when there are no tasks', () => {
+    render(
+      <TaskList
+        tasks={[]}
+        hasTasks={false}
+        isFiltering={false}
+      />
+    );
+    expect(screen.getByText('Add your first task!')).toBeInTheDocument();
+  });
+
+  it('shows default empty message while filtering', () => {
+    render(
+      <TaskList
+        tasks={[]}
+        hasTasks
+        isFiltering
+      />
+    );
     expect(screen.getByText('No tasks')).toBeInTheDocument();
   });
 });

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -7,7 +7,15 @@ import { useI18n } from '../../lib/i18n';
 
 export default function TasksView() {
   const { state, actions } = useTasksView();
-  const { tasks, tags, activeTags, tagToRemove, highlightedId } = state;
+  const {
+    tasks,
+    tags,
+    activeTags,
+    tagToRemove,
+    highlightedId,
+    hasTasks,
+    isFiltering,
+  } = state;
   const {
     addTask,
     addTag,
@@ -37,6 +45,8 @@ export default function TasksView() {
       <TaskList
         tasks={tasks}
         highlightedId={highlightedId}
+        hasTasks={hasTasks}
+        isFiltering={isFiltering}
       />
       {tagToRemove && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">

--- a/components/TasksView/useTasksView.ts
+++ b/components/TasksView/useTasksView.ts
@@ -76,6 +76,10 @@ export default function useTasksView() {
     return [...list, ...remaining];
   }, [filteredTasks, store.order]);
 
+  const totalTags = store.tags.length;
+  const hasTasks = store.tasks.length > 0;
+  const isFiltering = totalTags > 0 && activeTags.length !== totalTags;
+
   return {
     state: {
       tasks: orderedTasks,
@@ -83,6 +87,8 @@ export default function useTasksView() {
       activeTags,
       tagToRemove,
       highlightedId,
+      hasTasks,
+      isFiltering,
     },
     actions: {
       addTask: (input: {

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -106,7 +106,10 @@ const translations: Record<Language, any> = {
       finished: 'Time for "{task}" finished',
     },
     priority: { low: 'Low', medium: 'Medium', high: 'High' },
-    taskList: { noTasks: 'No tasks' },
+    taskList: {
+      noTasks: 'No tasks',
+      noTasksIntro: 'Add your first task!',
+    },
     tagFilter: {
       showAll: 'Show all',
       confirmDelete:
@@ -408,7 +411,10 @@ const translations: Record<Language, any> = {
       finished: 'Tiempo para "{task}" terminado',
     },
     priority: { low: 'Baja', medium: 'Media', high: 'Alta' },
-    taskList: { noTasks: 'No hay tareas' },
+    taskList: {
+      noTasks: 'No hay tareas',
+      noTasksIntro: '¡Añade tu primera tarea!',
+    },
     tagFilter: {
       showAll: 'Mostrar todas',
       confirmDelete:


### PR DESCRIPTION
## Summary
- add a dedicated empty-state message when the My Tasks board has no tasks yet
- keep the existing "No tasks" copy when tag filters hide results while updating translations
- cover the new empty states with unit tests

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d22836e77c832cad2257b329e4093f