### PR TITLE
Move My Day clear completed action to Done column

### DIFF
--- a/app/my-day/page.tsx
+++ b/app/my-day/page.tsx
@@ -8,9 +8,6 @@ import { useI18n } from '../../lib/i18n';
 export default function MyDayPage() {
   const { t } = useI18n();
   const tasks = useStore(state => state.tasks);
-  const clearCompletedMyDayTasks = useStore(
-    state => state.clearCompletedMyDayTasks
-  );
   const plannedTasks = tasks.filter(task => task.plannedFor !== null);
   const remainingTasks = plannedTasks.filter(task => task.dayStatus !== 'done');
   const progressPercent = plannedTasks.length
@@ -20,10 +17,6 @@ export default function MyDayPage() {
       )
     : 0;
   const hasMyDayTasks = plannedTasks.length > 0;
-  const allTasksCompleted = hasMyDayTasks && remainingTasks.length === 0;
-  const clearCompletedLabel = allTasksCompleted
-    ? t('myDayPage.progress.clearCompleted')
-    : undefined;
 
   return (
     <main
@@ -35,13 +28,7 @@ export default function MyDayPage() {
     >
       {hasMyDayTasks ? (
         <>
-          <ProgressBar
-            percent={progressPercent}
-            onClearCompleted={
-              allTasksCompleted ? clearCompletedMyDayTasks : undefined
-            }
-            clearCompletedLabel={clearCompletedLabel}
-          />
+          <ProgressBar percent={progressPercent} />
           <Board mode="my-day" />
         </>
       ) : (

--- a/components/Column/Column.tsx
+++ b/components/Column/Column.tsx
@@ -5,6 +5,8 @@ import {
 } from '@dnd-kit/sortable';
 import { Task } from '../../lib/types';
 import { getDayStatusIcon, type DayStatus } from '../../lib/dayStatus';
+import { useStore } from '../../lib/store';
+import { useI18n } from '../../lib/i18n';
 import TaskCard from '../TaskCard/TaskCard';
 import useColumn, { UseColumnProps } from './useColumn';
 
@@ -25,21 +27,36 @@ export default function Column({
   const { containerClasses, listClasses } = state;
   const { setNodeRef } = actions;
   const StatusIcon = status ? getDayStatusIcon(status) : null;
+  const { t } = useI18n();
+  const clearCompletedMyDayTasks = useStore(s => s.clearCompletedMyDayTasks);
+  const showClearCompletedAction =
+    mode === 'my-day' && id === 'done' && tasks.length >= 2;
 
   return (
     <div
       ref={setNodeRef}
       className={containerClasses}
     >
-      <h2 className="mb-6 flex items-center gap-2 text-lg font-semibold">
-        {StatusIcon ? (
-          <StatusIcon
-            aria-hidden="true"
-            className="h-5 w-5 text-blue-600 dark:text-blue-200"
-          />
+      <div className="mb-6 flex items-center justify-between gap-2">
+        <h2 className="flex items-center gap-2 text-lg font-semibold">
+          {StatusIcon ? (
+            <StatusIcon
+              aria-hidden="true"
+              className="h-5 w-5 text-blue-600 dark:text-blue-200"
+            />
+          ) : null}
+          {title}
+        </h2>
+        {showClearCompletedAction ? (
+          <button
+            type="button"
+            onClick={clearCompletedMyDayTasks}
+            className="rounded px-1 text-sm font-medium text-[#57886C] underline-offset-2 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#57886C]"
+          >
+            {t('myDayPage.progress.clearCompleted')}
+          </button>
         ) : null}
-        {title}
-      </h2>
+      </div>
       <SortableContext
         id={id}
         items={tasks.map(t => t.id)}

--- a/components/Column/__tests__/Column.test.tsx
+++ b/components/Column/__tests__/Column.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '../../../test/test-utils';
 import Column from '../Column';
 import useColumn from '../useColumn';
+import { useStore } from '../../../lib/store';
 
 jest.mock('../useColumn');
 jest.mock('../../TaskCard/TaskCard', () => ({
@@ -11,11 +12,24 @@ jest.mock('../../TaskCard/TaskCard', () => ({
 const mockUseColumn = useColumn as jest.MockedFunction<typeof useColumn>;
 
 describe('Column', () => {
+  const originalClearCompleted = useStore.getState().clearCompletedMyDayTasks;
+
   beforeEach(() => {
     mockUseColumn.mockReturnValue({
       state: { containerClasses: 'container', listClasses: 'list' },
       actions: { setNodeRef: jest.fn() },
     } as any);
+    useStore.setState(
+      { clearCompletedMyDayTasks: originalClearCompleted } as any,
+      false
+    );
+  });
+
+  afterAll(() => {
+    useStore.setState(
+      { clearCompletedMyDayTasks: originalClearCompleted } as any,
+      false
+    );
   });
 
   it('renders title and tasks', () => {
@@ -42,5 +56,72 @@ describe('Column', () => {
 
     expect(screen.getByText('Col')).toBeInTheDocument();
     expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('does not render clear action when fewer than two tasks are done', () => {
+    const tasks = [
+      {
+        id: 't1',
+        title: 'Only task',
+        createdAt: '',
+        listId: 'l1',
+        tags: [],
+        priority: 'medium' as const,
+        plannedFor: null,
+      },
+    ];
+
+    render(
+      <Column
+        id="done"
+        title="Done"
+        tasks={tasks}
+        mode="my-day"
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /remove completed tasks/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders clear action and triggers handler for done column with multiple tasks', () => {
+    const tasks = [
+      {
+        id: 't1',
+        title: 'Task 1',
+        createdAt: '',
+        listId: 'l1',
+        tags: [],
+        priority: 'high' as const,
+        plannedFor: null,
+      },
+      {
+        id: 't2',
+        title: 'Task 2',
+        createdAt: '',
+        listId: 'l1',
+        tags: [],
+        priority: 'low' as const,
+        plannedFor: null,
+      },
+    ];
+    const clearSpy = jest.fn();
+    useStore.setState({ clearCompletedMyDayTasks: clearSpy } as any, false);
+
+    render(
+      <Column
+        id="done"
+        title="Done"
+        tasks={tasks}
+        mode="my-day"
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: /remove completed tasks/i,
+    });
+    button.click();
+    expect(clearSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- move the My Day clear completed button from the progress bar to the Done column header
- only show the action when at least two tasks are completed while keeping recurring task handling intact

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npx prettier --check app/my-day/page.tsx components/Column/Column.tsx components/Column/__tests__/Column.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d303905194832cbcbd66e91d598d68