### PR TITLE
Fix favorite tag auto-selection when adding tasks

### DIFF
--- a/lib/__tests__/addTask.test.ts
+++ b/lib/__tests__/addTask.test.ts
@@ -1,0 +1,54 @@
+import { useStore } from '../store';
+
+describe('addTask favorite tags behavior', () => {
+  beforeEach(() => {
+    useStore.getState().clearAll();
+  });
+
+  it('marks the last tag as favorite when there are no other favorites', () => {
+    useStore.getState().addTag({
+      id: 'tag-1',
+      label: 'work',
+      color: '#f00',
+      favorite: false,
+    });
+
+    useStore.getState().addTask({
+      title: 'Task with first tag',
+      tags: ['work'],
+      priority: 'medium',
+    });
+
+    const tags = useStore.getState().tags;
+    const workTag = tags.find(tag => tag.label === 'work');
+    expect(workTag?.favorite).toBe(true);
+  });
+
+  it('keeps the new tag unfavorited when another favorite already exists', () => {
+    useStore.getState().addTag({
+      id: 'tag-favorite',
+      label: 'favorite',
+      color: '#0f0',
+      favorite: true,
+    });
+
+    useStore.getState().addTag({
+      id: 'tag-new',
+      label: 'new',
+      color: '#00f',
+      favorite: false,
+    });
+
+    useStore.getState().addTask({
+      title: 'Task with new tag',
+      tags: ['new'],
+      priority: 'medium',
+    });
+
+    const tags = useStore.getState().tags;
+    const newTag = tags.find(tag => tag.label === 'new');
+    expect(newTag?.favorite).toBe(false);
+    const favoriteTag = tags.find(tag => tag.label === 'favorite');
+    expect(favoriteTag?.favorite).toBe(true);
+  });
+});

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -371,9 +371,15 @@ export const useStore = create<Store>((set, get) => ({
       const priorityKey = `priority-${priority}`;
       newOrder[priorityKey] = [...(newOrder[priorityKey] || []), id];
       const lastTag = tags[tags.length - 1];
-      const updatedTags = state.tags.map(t =>
-        t.label === lastTag ? { ...t, favorite: true } : t
+      const hasOtherFavorite = state.tags.some(
+        tag => tag.favorite && tag.label !== lastTag
       );
+      const updatedTags =
+        lastTag && !hasOtherFavorite
+          ? state.tags.map(t =>
+              t.label === lastTag ? { ...t, favorite: true } : t
+            )
+          : state.tags;
       return {
         tasks: [...state.tasks, task],
         order: newOrder,


### PR DESCRIPTION
## Summary
- update the store to avoid auto-favoriting a tag when other favorites already exist
- add unit tests to cover the updated addTask favorite tag logic

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d8f47eb6d4832caeecfd767c0e0cea