### PR TITLE
feat: toggle My Tasks add form on mobile

### DIFF
--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import AddTask from '../AddTask/AddTask';
 import TaskList from '../TaskList/TaskList';
@@ -29,35 +29,53 @@ export default function TasksView() {
     cancelRemoveTag,
   } = actions;
   const { t } = useI18n();
-  const [showMobileAddTask, setShowMobileAddTask] = useState(false);
+  const [showMobileAddTask, setShowMobileAddTask] = useState(!hasTasks);
+
+  useEffect(() => {
+    if (!hasTasks) {
+      setShowMobileAddTask(true);
+    }
+  }, [hasTasks]);
 
   const toggleMobileAddTask = () => {
     setShowMobileAddTask(prev => !prev);
   };
   return (
     <main>
-      <div className="sm:hidden">
-        <button
-          type="button"
-          onClick={toggleMobileAddTask}
-          className="mx-4 mt-4 flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
-          aria-expanded={showMobileAddTask}
-          aria-controls="tasks-view-add-task"
-        >
-          {showMobileAddTask ? (
-            <X className="h-4 w-4" />
-          ) : (
-            <Plus className="h-4 w-4" />
-          )}
-          {showMobileAddTask
-            ? t('tasksView.mobileAddTask.hide')
-            : t('tasksView.mobileAddTask.show')}
-        </button>
-      </div>
+      {hasTasks && !showMobileAddTask && (
+        <div className="sm:hidden">
+          <div className="flex justify-center px-4 pt-4">
+            <button
+              type="button"
+              onClick={toggleMobileAddTask}
+              className="flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
+              aria-expanded={showMobileAddTask}
+              aria-controls="tasks-view-add-task"
+            >
+              <Plus className="h-4 w-4" />
+              {t('tasksView.mobileAddTask.show')}
+            </button>
+          </div>
+        </div>
+      )}
       <div
         id="tasks-view-add-task"
-        className={`${showMobileAddTask ? '' : 'hidden'} sm:block`}
+        className={`${hasTasks && !showMobileAddTask ? 'hidden' : ''} sm:block`}
       >
+        {hasTasks && showMobileAddTask && (
+          <div className="flex justify-end px-4 pt-4 sm:hidden">
+            <button
+              type="button"
+              onClick={toggleMobileAddTask}
+              className="flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
+              aria-expanded={showMobileAddTask}
+              aria-controls="tasks-view-add-task"
+            >
+              <X className="h-4 w-4" />
+              {t('tasksView.mobileAddTask.hide')}
+            </button>
+          </div>
+        )}
         <AddTask
           addTask={addTask}
           tags={tags}

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useState } from 'react';
+import { Plus, X } from 'lucide-react';
 import AddTask from '../AddTask/AddTask';
 import TaskList from '../TaskList/TaskList';
 import TagFilter from '../TagFilter/TagFilter';
@@ -27,13 +29,41 @@ export default function TasksView() {
     cancelRemoveTag,
   } = actions;
   const { t } = useI18n();
+  const [showMobileAddTask, setShowMobileAddTask] = useState(false);
+
+  const toggleMobileAddTask = () => {
+    setShowMobileAddTask(prev => !prev);
+  };
   return (
     <main>
-      <AddTask
-        addTask={addTask}
-        tags={tags}
-        addTag={addTag}
-      />
+      <div className="sm:hidden">
+        <button
+          type="button"
+          onClick={toggleMobileAddTask}
+          className="mx-4 mt-4 flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
+          aria-expanded={showMobileAddTask}
+          aria-controls="tasks-view-add-task"
+        >
+          {showMobileAddTask ? (
+            <X className="h-4 w-4" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+          {showMobileAddTask
+            ? t('tasksView.mobileAddTask.hide')
+            : t('tasksView.mobileAddTask.show')}
+        </button>
+      </div>
+      <div
+        id="tasks-view-add-task"
+        className={`${showMobileAddTask ? '' : 'hidden'} sm:block`}
+      >
+        <AddTask
+          addTask={addTask}
+          tags={tags}
+          addTag={addTag}
+        />
+      </div>
       <TagFilter
         tags={tags}
         activeTags={activeTags}

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { Plus, X } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import AddTask from '../AddTask/AddTask';
 import TaskList from '../TaskList/TaskList';
 import TagFilter from '../TagFilter/TagFilter';
@@ -37,8 +37,8 @@ export default function TasksView() {
     }
   }, [hasTasks]);
 
-  const toggleMobileAddTask = () => {
-    setShowMobileAddTask(prev => !prev);
+  const showMobileForm = () => {
+    setShowMobileAddTask(true);
   };
   return (
     <main>
@@ -47,7 +47,7 @@ export default function TasksView() {
           <div className="flex justify-center px-4 pt-4">
             <button
               type="button"
-              onClick={toggleMobileAddTask}
+              onClick={showMobileForm}
               className="flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
               aria-expanded={showMobileAddTask}
               aria-controls="tasks-view-add-task"
@@ -60,22 +60,8 @@ export default function TasksView() {
       )}
       <div
         id="tasks-view-add-task"
-        className={`${hasTasks && !showMobileAddTask ? 'hidden' : ''} sm:block`}
+        className={`${hasTasks && !showMobileAddTask ? 'hidden ' : ''}sm:block`}
       >
-        {hasTasks && showMobileAddTask && (
-          <div className="flex justify-end px-4 pt-4 sm:hidden">
-            <button
-              type="button"
-              onClick={toggleMobileAddTask}
-              className="flex items-center gap-2 rounded bg-[#57886C] px-4 py-2 text-sm text-white hover:brightness-110 focus:ring"
-              aria-expanded={showMobileAddTask}
-              aria-controls="tasks-view-add-task"
-            >
-              <X className="h-4 w-4" />
-              {t('tasksView.mobileAddTask.hide')}
-            </button>
-          </div>
-        )}
         <AddTask
           addTask={addTask}
           tags={tags}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -113,7 +113,6 @@ const translations: Record<Language, any> = {
     tasksView: {
       mobileAddTask: {
         show: 'Add task',
-        hide: 'Hide form',
       },
     },
     tagFilter: {
@@ -424,7 +423,6 @@ const translations: Record<Language, any> = {
     tasksView: {
       mobileAddTask: {
         show: 'Añadir tarea',
-        hide: 'Ocultar formulario',
       },
     },
     tagFilter: {

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -110,6 +110,12 @@ const translations: Record<Language, any> = {
       noTasks: 'No tasks',
       noTasksIntro: 'Add your first task!',
     },
+    tasksView: {
+      mobileAddTask: {
+        show: 'Add task',
+        hide: 'Hide form',
+      },
+    },
     tagFilter: {
       showAll: 'Show all',
       confirmDelete:
@@ -414,6 +420,12 @@ const translations: Record<Language, any> = {
     taskList: {
       noTasks: 'No hay tareas',
       noTasksIntro: '¡Añade tu primera tarea!',
+    },
+    tasksView: {
+      mobileAddTask: {
+        show: 'Añadir tarea',
+        hide: 'Ocultar formulario',
+      },
     },
     tagFilter: {
       showAll: 'Mostrar todas',


### PR DESCRIPTION
## Summary
- hide the My Tasks add form behind a toggle on mobile while keeping the desktop experience unchanged
- add localized labels for the mobile toggle button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ffc87000832cb2a03f16be7e746f