### PR TITLE
Fix notification icon styling

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -17,6 +17,7 @@ import {
   Languages,
 } from 'lucide-react';
 import { Language, LANGUAGES } from '../../lib/i18n';
+import { getNotificationIconClasses } from '../../lib/notifications';
 import Icon from '../Icon/Icon';
 import useHeader from './useHeader';
 
@@ -268,7 +269,9 @@ export default function Header() {
                 }}
               >
                 <div className="flex items-start gap-4">
-                  <NotificationIcon className="mt-1 h-6 w-6 flex-shrink-0 text-blue-600 dark:text-blue-300" />
+                  <NotificationIcon
+                    className={`mt-1 h-6 w-6 flex-shrink-0 ${getNotificationIconClasses(latestUnreadNotification.type)}`}
+                  />
                   <div className="min-w-0">
                     <p className="text-base font-semibold text-slate-900 dark:text-slate-100">
                       {popoverTitle}

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -4,6 +4,7 @@ import { Info, AlertTriangle, Lightbulb, X } from 'lucide-react';
 import { useI18n } from '../../lib/i18n';
 import { Notification } from '../../lib/types';
 import { useStore } from '../../lib/store';
+import { getNotificationIconClasses } from '../../lib/notifications';
 
 interface Props {
   notification: Notification;
@@ -38,12 +39,10 @@ export default function NotificationCard({ notification }: Props) {
         />
       </button>
       <div className="flex items-start gap-4">
-        <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-300">
-          <Icon
-            className="h-6 w-6"
-            aria-hidden="true"
-          />
-        </div>
+        <Icon
+          className={`mt-1 h-6 w-6 flex-shrink-0 ${getNotificationIconClasses(notification.type)}`}
+          aria-hidden="true"
+        />
         <div className="flex-1 space-y-3 pr-8">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
             {title}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,17 @@
+import { Notification } from './types';
+
+const ICON_COLOR_CLASSES: Record<Notification['type'], string> = {
+  info: 'text-blue-600 dark:text-blue-300',
+  tip: 'text-amber-500 dark:text-amber-300',
+  alert: 'text-red-500 dark:text-red-300',
+};
+
+export function getNotificationIconClasses(
+  type: Notification['type'] | undefined
+) {
+  if (!type) {
+    return ICON_COLOR_CLASSES.info;
+  }
+
+  return ICON_COLOR_CLASSES[type];
+}


### PR DESCRIPTION
## Summary
- remove the background treatment from notification icons and centralize their color styles
- apply the shared icon styling to the floating notification preview and full notification cards for a cleaner look

## Testing
- npm run lint
- npm run typecheck
- npx prettier --check components/Header/Header.tsx components/NotificationCard/NotificationCard.tsx lib/notifications.ts

------
https://chatgpt.com/codex/tasks/task_e_68d90b28bf1c832c93653e76fd665f08