### PR TITLE
Simplify main task styling in My Day

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,51 +9,6 @@ body,
   height: 100%;
 }
 
-@keyframes main-task-wow {
-  0% {
-    transform: scale(0.92) rotate(-1deg);
-    outline-width: 6px;
-    outline-offset: 6px;
-  }
-  45% {
-    transform: scale(1.05) rotate(1deg);
-    outline-width: 3px;
-    outline-offset: 5px;
-  }
-  80% {
-    transform: scale(0.98) rotate(-0.5deg);
-    outline-width: 2.5px;
-    outline-offset: 4.5px;
-  }
-  100% {
-    transform: scale(1);
-    outline-width: 2px;
-    outline-offset: 4px;
-  }
-}
-
-@keyframes main-task-ripple {
-  0% {
-    transform: translate(-50%, -50%) scale(0.55);
-    opacity: 0.8;
-  }
-  60% {
-    opacity: 0.4;
-  }
-  100% {
-    transform: translate(-50%, -50%) scale(1.3);
-    opacity: 0;
-  }
-}
-
-.animate-main-task-wow {
-  animation: main-task-wow 0.65s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.animate-main-task-ripple {
-  animation: main-task-ripple 0.75s ease-out forwards;
-}
-
 @media (prefers-color-scheme: dark) {
   * {
     scrollbar-width: thin;

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -25,7 +25,9 @@ export default function TaskCard(props: UseTaskCardProps) {
   const [showTimer, setShowTimer] = useState(() => shouldForceShowTimer);
   const isTimerVisible = showTimer || shouldForceShowTimer;
 
-  const priorityClass = priorityColors[task.priority];
+  const priorityClass = isMainTask
+    ? 'border-l-amber-400 dark:border-l-amber-300'
+    : priorityColors[task.priority];
   const cardClasses = [
     'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-4 transition-colors duration-300 ease-out',
     priorityClass,

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState, type MouseEvent } from 'react';
-import { Check, Trash2, Play, Clock } from 'lucide-react';
+import { Check, Trash2, Play, Clock, Star } from 'lucide-react';
 import Link from '../Link/Link';
 import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
@@ -31,10 +31,12 @@ export default function TaskCard(props: UseTaskCardProps) {
     priorityClass,
     isMainTask
       ? [
-          'bg-white text-gray-900',
+          'bg-amber-100 text-gray-900',
           'border border-amber-200 hover:border-amber-300',
-          'dark:bg-gray-900 dark:text-amber-50',
+          'outline outline-2 outline-amber-300 outline-offset-4 hover:outline-amber-400',
+          'dark:bg-amber-500/20 dark:text-amber-50',
           'dark:border-amber-300/70 dark:hover:border-amber-200/70',
+          'dark:outline-amber-300/70 dark:hover:outline-amber-200/70',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
   ]
@@ -127,15 +129,16 @@ export default function TaskCard(props: UseTaskCardProps) {
                   aria-pressed={isMainTask}
                   aria-label={mainTaskLabel}
                   title={t('taskCard.mainTaskTooltip')}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
+                  className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
                     isMainTask
-                      ? 'border border-amber-300 text-amber-700 hover:text-amber-600 dark:border-amber-200/70 dark:text-amber-100'
-                      : 'border border-transparent text-gray-500 hover:border-amber-200 hover:text-amber-500 dark:text-gray-400 dark:hover:border-amber-300/60 dark:hover:text-amber-200'
+                      ? 'text-amber-600 hover:text-amber-500 dark:text-amber-200 dark:hover:text-amber-100'
+                      : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
                   }`}
                 >
-                  {isMainTask
-                    ? t('taskCard.mainTaskTooltip')
-                    : t('taskCard.setMainTask')}
+                  <Star
+                    className="h-4 w-4"
+                    strokeWidth={isMainTask ? 1.5 : 2}
+                  />
                 </button>
               </>
             ) : (

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState, type MouseEvent } from 'react';
-import { Check, Trash2, Play, Clock, Star } from 'lucide-react';
+import { Check, Trash2, Play, Clock } from 'lucide-react';
 import Link from '../Link/Link';
 import Timer from './Timer';
 import useTaskCard, { UseTaskCardProps } from './useTaskCard';
@@ -23,24 +23,20 @@ export default function TaskCard(props: UseTaskCardProps) {
   const shouldForceShowTimer =
     mode === 'my-day' && task.dayStatus === 'doing' && Boolean(timer?.running);
   const [showTimer, setShowTimer] = useState(() => shouldForceShowTimer);
-  const [isMainTaskEntering, setIsMainTaskEntering] = useState(false);
   const isTimerVisible = showTimer || shouldForceShowTimer;
 
   const priorityClass = priorityColors[task.priority];
   const cardClasses = [
-    'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-4 transition-all duration-500 ease-out transform-gpu',
+    'group relative z-0 rounded border-l-4 p-4 cursor-grab focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-4 transition-colors duration-300 ease-out',
     priorityClass,
     isMainTask
       ? [
-          'bg-amber-100 text-gray-900',
+          'bg-white text-gray-900',
           'border border-amber-200 hover:border-amber-300',
-          'outline outline-2 outline-amber-300 outline-offset-4 hover:outline-amber-400',
-          'dark:bg-amber-500/20 dark:text-amber-50',
+          'dark:bg-gray-900 dark:text-amber-50',
           'dark:border-amber-300/70 dark:hover:border-amber-200/70',
-          'dark:outline-amber-300/70 dark:hover:outline-amber-200/70',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
-    isMainTaskEntering ? 'animate-main-task-wow' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -61,21 +57,6 @@ export default function TaskCard(props: UseTaskCardProps) {
     }
   }, [shouldForceShowTimer]);
 
-  useEffect(() => {
-    if (!isMainTask) {
-      setIsMainTaskEntering(false);
-      return;
-    }
-    setIsMainTaskEntering(true);
-    const timeoutId = window.setTimeout(() => {
-      setIsMainTaskEntering(false);
-    }, 800);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [isMainTask]);
-
   const handleToggleTimer = () => {
     if (shouldForceShowTimer) {
       return;
@@ -92,14 +73,6 @@ export default function TaskCard(props: UseTaskCardProps) {
       className={cardClasses}
       data-main-task={isMainTask || undefined}
     >
-      {isMainTask && (
-        <span
-          aria-hidden
-          className={`pointer-events-none absolute left-1/2 top-1/2 h-[18rem] w-[18rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-300/35 blur-3xl ${
-            isMainTaskEntering ? 'animate-main-task-ripple' : 'opacity-0'
-          }`}
-        />
-      )}
       <div className="relative z-10">
         <div
           className={`flex justify-between ${
@@ -154,19 +127,15 @@ export default function TaskCard(props: UseTaskCardProps) {
                   aria-pressed={isMainTask}
                   aria-label={mainTaskLabel}
                   title={t('taskCard.mainTaskTooltip')}
-                  className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 ${
                     isMainTask
-                      ? 'bg-amber-200/60 text-amber-700 hover:text-amber-600 dark:bg-amber-400/20 dark:text-amber-200'
-                      : 'text-gray-400 hover:text-amber-400 dark:text-gray-500 dark:hover:text-amber-300'
+                      ? 'border border-amber-300 text-amber-700 hover:text-amber-600 dark:border-amber-200/70 dark:text-amber-100'
+                      : 'border border-transparent text-gray-500 hover:border-amber-200 hover:text-amber-500 dark:text-gray-400 dark:hover:border-amber-300/60 dark:hover:text-amber-200'
                   }`}
                 >
-                  <Star
-                    className={`h-4 w-4 transition-transform duration-300 ease-out ${
-                      isMainTask ? 'scale-110 rotate-3' : ''
-                    }`}
-                    strokeWidth={isMainTask ? 1.5 : 2}
-                    fill={isMainTask ? 'currentColor' : 'none'}
-                  />
+                  {isMainTask
+                    ? t('taskCard.mainTaskTooltip')
+                    : t('taskCard.setMainTask')}
                 </button>
               </>
             ) : (

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -33,10 +33,8 @@ export default function TaskCard(props: UseTaskCardProps) {
       ? [
           'bg-amber-100 text-gray-900',
           'border border-amber-200 hover:border-amber-300',
-          'outline outline-2 outline-amber-300 outline-offset-4 hover:outline-amber-400',
           'dark:bg-amber-500/20 dark:text-amber-50',
           'dark:border-amber-300/70 dark:hover:border-amber-200/70',
-          'dark:outline-amber-300/70 dark:hover:outline-amber-200/70',
         ].join(' ')
       : 'bg-gray-100 dark:bg-gray-800 hover:shadow-md',
   ]


### PR DESCRIPTION
## Summary
- simplify the My Day main task card by removing animated effects and glow styling
- replace the star toggle with a text-based control to match the pared down look
- delete the unused CSS animation definitions related to the old presentation

## Testing
- npm run test -- TaskCard

------
https://chatgpt.com/codex/tasks/task_e_68da049f8264832c8e7398c52b0dc3ec