### PR TITLE
Adjust timer completion notifications to info style

### DIFF
--- a/components/TaskTimerManager/TaskTimerManager.tsx
+++ b/components/TaskTimerManager/TaskTimerManager.tsx
@@ -85,7 +85,7 @@ export default function TaskTimerManager() {
               : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
           state.addNotification({
             id: `timer-finished-${taskId}-${randomId}`,
-            type: 'alert',
+            type: 'info',
             titleKey: 'notifications.timerFinished.title',
             descriptionKey: 'notifications.timerFinished.description',
             title: t('notifications.timerFinished.title'),


### PR DESCRIPTION
## Summary
- update timer-finished notifications to use the info style so the UI no longer shows an error-colored icon

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db53ac02d0832cbb85173fc62e6122