### PR TITLE
Add demo templates page with technical lead sample data

### DIFF
--- a/app/demo-templates/page.tsx
+++ b/app/demo-templates/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { DEMO_TEMPLATES } from '../../lib/demoTemplates';
+import { useI18n } from '../../lib/i18n';
+import { useStore } from '../../lib/store';
+
+export default function DemoTemplatesPage() {
+  const { t } = useI18n();
+  const { tasks, tags, importData } = useStore(state => ({
+    tasks: state.tasks,
+    tags: state.tags,
+    importData: state.importData,
+  }));
+
+  const handleImportTemplate = (templateId: string) => {
+    const template = DEMO_TEMPLATES.find(item => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const hasExistingData = tasks.length > 0 || tags.length > 0;
+    if (hasExistingData) {
+      const proceed = window.confirm(t('demoTemplatesPage.confirmExisting'));
+      if (!proceed) {
+        return;
+      }
+    }
+
+    const nextState = template.createState();
+    importData(nextState);
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-16">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-bold">{t('demoTemplatesPage.title')}</h1>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          {t('demoTemplatesPage.intro')}
+        </p>
+      </header>
+      <section className="grid gap-6 md:grid-cols-2">
+        {DEMO_TEMPLATES.map(template => {
+          const rolePath =
+            `demoTemplatesPage.roles.${template.roleKey}` as const;
+          return (
+            <article
+              key={template.id}
+              className="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-gray-700 dark:bg-gray-900/60"
+            >
+              <h2 className="text-xl font-semibold">
+                {t(`${rolePath}.title`)}
+              </h2>
+              <p className="mt-2 flex-1 text-gray-600 dark:text-gray-300">
+                {t(`${rolePath}.description`)}
+              </p>
+              <button
+                type="button"
+                onClick={() => handleImportTemplate(template.id)}
+                className="mt-6 inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:hover:bg-blue-500 dark:focus-visible:ring-offset-gray-900"
+              >
+                {t(`${rolePath}.importCta`)}
+              </button>
+            </article>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/app/demo-templates/page.tsx
+++ b/app/demo-templates/page.tsx
@@ -1,16 +1,38 @@
 'use client';
 
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DEMO_TEMPLATES } from '../../lib/demoTemplates';
 import { useI18n } from '../../lib/i18n';
 import { useStore } from '../../lib/store';
 
 export default function DemoTemplatesPage() {
   const { t } = useI18n();
+  const router = useRouter();
   const { tasks, tags, importData } = useStore(state => ({
     tasks: state.tasks,
     tags: state.tags,
     importData: state.importData,
   }));
+  const [importedTemplateId, setImportedTemplateId] = useState<string | null>(
+    null
+  );
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+
+  const importedTemplate = useMemo(() => {
+    if (!importedTemplateId) {
+      return null;
+    }
+    return DEMO_TEMPLATES.find(item => item.id === importedTemplateId) ?? null;
+  }, [importedTemplateId]);
+  const importedTemplateTitle = useMemo(() => {
+    if (!importedTemplate) {
+      return null;
+    }
+    const roleTitleKey =
+      `demoTemplatesPage.roles.${importedTemplate.roleKey}.title` as const;
+    return t(roleTitleKey);
+  }, [importedTemplate, t]);
 
   const handleImportTemplate = (templateId: string) => {
     const template = DEMO_TEMPLATES.find(item => item.id === templateId);
@@ -28,6 +50,8 @@ export default function DemoTemplatesPage() {
 
     const nextState = template.createState();
     importData(nextState);
+    setImportedTemplateId(template.id);
+    setShowSuccessModal(true);
   };
 
   return (
@@ -56,7 +80,7 @@ export default function DemoTemplatesPage() {
               <button
                 type="button"
                 onClick={() => handleImportTemplate(template.id)}
-                className="mt-6 inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:hover:bg-blue-500 dark:focus-visible:ring-offset-gray-900"
+                className="mt-6 inline-flex items-center justify-center rounded-lg bg-[#57886C] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-[#57886C] dark:focus-visible:ring-offset-gray-900"
               >
                 {t(`${rolePath}.importCta`)}
               </button>
@@ -64,6 +88,47 @@ export default function DemoTemplatesPage() {
           );
         })}
       </section>
+      {showSuccessModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900"
+          >
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {t('demoTemplatesPage.successTitle')}
+            </h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+              {t('demoTemplatesPage.successDescription')}
+            </p>
+            {importedTemplate && importedTemplateTitle ? (
+              <p className="mt-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                {t('demoTemplatesPage.successRoleLabel')}{' '}
+                <span className="font-semibold">{importedTemplateTitle}</span>
+              </p>
+            ) : null}
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setShowSuccessModal(false)}
+                className="inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900"
+              >
+                {t('actions.close')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowSuccessModal(false);
+                  router.push('/my-tasks');
+                }}
+                className="inline-flex items-center justify-center rounded-lg bg-[#57886C] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-[#57886C] dark:focus-visible:ring-offset-gray-900"
+              >
+                {t('demoTemplatesPage.viewDemoCta')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -30,6 +30,12 @@ export default function Footer() {
           {t('footer.faqs')}
         </Link>
         <Link
+          href="/demo-templates"
+          className="hover:underline"
+        >
+          {t('footer.demoTemplates')}
+        </Link>
+        <Link
           href="/privacy"
           className="hover:underline"
         >

--- a/lib/demoTemplates.ts
+++ b/lib/demoTemplates.ts
@@ -1,0 +1,283 @@
+import { PersistedState, List, Tag, Task } from './types';
+
+type DemoTemplateRoleKey = 'techLead';
+
+export type DemoTemplate = {
+  id: string;
+  roleKey: DemoTemplateRoleKey;
+  createState: () => PersistedState;
+};
+
+const DEFAULT_LISTS: List[] = [
+  { id: 'ideas', title: 'Ideas', order: 0 },
+  { id: 'backlog', title: 'Backlog', order: 1 },
+  { id: 'inprogress', title: 'In Progress', order: 2 },
+  { id: 'done', title: 'Done', order: 3 },
+];
+
+const createEmptyWorkSchedule = () => ({
+  monday: [],
+  tuesday: [],
+  wednesday: [],
+  thursday: [],
+  friday: [],
+  saturday: [],
+  sunday: [],
+});
+
+const createTechLeadTemplateState = (): PersistedState => {
+  const todayKey = new Date().toISOString().slice(0, 10);
+  const baseTasks: Task[] = [
+    {
+      id: 'tech-lead-task-001',
+      title:
+        'Draft async API gateway migration plan https://confluence.example.com/display/PLAT/Async-Gateway-Migration-Outline',
+      createdAt: '2024-05-01T09:00:00.000Z',
+      priority: 'medium',
+      tags: ['Analysis'],
+      listId: 'ideas',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-002',
+      title: 'Document incident response playbook for database failover',
+      createdAt: '2024-05-02T10:30:00.000Z',
+      priority: 'high',
+      tags: ['Task', 'Analysis'],
+      listId: 'ideas',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-003',
+      title: 'Triage overnight incidents backlog',
+      createdAt: '2024-05-06T07:30:00.000Z',
+      priority: 'high',
+      tags: ['Task', 'Monitor'],
+      listId: 'backlog',
+      plannedFor: todayKey,
+      dayStatus: 'todo',
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-004',
+      title: 'Prepare architecture review session with data science team',
+      createdAt: '2024-05-06T12:15:00.000Z',
+      priority: 'medium',
+      tags: ['Task'],
+      listId: 'backlog',
+      plannedFor: todayKey,
+      dayStatus: 'todo',
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-005',
+      title:
+        'Review outstanding PRs from platform squad https://github.com/example/organization/repo/pull/482',
+      createdAt: '2024-05-07T08:20:00.000Z',
+      priority: 'high',
+      tags: ['Review PR'],
+      listId: 'backlog',
+      plannedFor: todayKey,
+      dayStatus: 'todo',
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-006',
+      title: 'Debug flaky integration test suite for payments service',
+      createdAt: '2024-05-08T14:45:00.000Z',
+      priority: 'high',
+      tags: ['Task', 'Analysis'],
+      listId: 'inprogress',
+      plannedFor: todayKey,
+      dayStatus: 'doing',
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-007',
+      title: 'Sync with product lead on roadmap adjustments',
+      createdAt: '2024-05-09T11:10:00.000Z',
+      priority: 'medium',
+      tags: ['Task'],
+      listId: 'inprogress',
+      plannedFor: todayKey,
+      dayStatus: 'done',
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-008',
+      title: 'Plan load testing scenario for messaging layer',
+      createdAt: '2024-05-10T09:50:00.000Z',
+      priority: 'medium',
+      tags: ['Analysis'],
+      listId: 'backlog',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-009',
+      title:
+        'Run monitoring health check on staging observability dashboard https://status.example.io/dashboards/platform/infra/overview',
+      createdAt: '2024-05-11T16:05:00.000Z',
+      priority: 'medium',
+      tags: ['Monitor'],
+      listId: 'inprogress',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-010',
+      title: 'Write weekly leadership update for stakeholders',
+      createdAt: '2024-05-12T08:35:00.000Z',
+      priority: 'low',
+      tags: ['Task'],
+      listId: 'backlog',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-011',
+      title: 'Organize knowledge-sharing session on distributed tracing',
+      createdAt: '2024-05-13T13:00:00.000Z',
+      priority: 'medium',
+      tags: ['Task', 'Analysis'],
+      listId: 'backlog',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-012',
+      title: 'Refactor onboarding documentation for new engineers',
+      createdAt: '2024-05-14T09:40:00.000Z',
+      priority: 'low',
+      tags: ['Task'],
+      listId: 'done',
+      plannedFor: null,
+      repeat: null,
+    },
+    {
+      id: 'tech-lead-task-013',
+      title: 'Review planning priorities for the coming week',
+      createdAt: '2024-05-12T07:00:00.000Z',
+      priority: 'medium',
+      tags: ['Task'],
+      listId: 'backlog',
+      plannedFor: null,
+      repeat: {
+        frequency: 'weekly',
+        days: ['monday'],
+        autoAddToMyDay: true,
+        lastOccurrenceDate: null,
+      },
+    },
+    {
+      id: 'tech-lead-task-014',
+      title: 'Refine next sprint backlog with staff engineers',
+      createdAt: '2024-05-12T07:30:00.000Z',
+      priority: 'medium',
+      tags: ['Review PR', 'Task'],
+      listId: 'backlog',
+      plannedFor: null,
+      repeat: {
+        frequency: 'weekly',
+        days: ['thursday'],
+        autoAddToMyDay: true,
+        lastOccurrenceDate: null,
+      },
+    },
+    {
+      id: 'tech-lead-task-015',
+      title: 'Evaluate vendor proposal for error tracking upgrade',
+      createdAt: '2024-05-15T10:25:00.000Z',
+      priority: 'medium',
+      tags: ['Analysis'],
+      listId: 'ideas',
+      plannedFor: null,
+      repeat: null,
+    },
+  ];
+
+  const tasks: Task[] = baseTasks.map(task => ({ ...task }));
+
+  const tags: Tag[] = [
+    {
+      id: 'tag-task',
+      label: 'Task',
+      color: '#4CAF50',
+      favorite: true,
+    },
+    {
+      id: 'tag-analysis',
+      label: 'Analysis',
+      color: '#2196F3',
+      favorite: false,
+    },
+    {
+      id: 'tag-review-pr',
+      label: 'Review PR',
+      color: '#FF6F00',
+      favorite: false,
+    },
+    {
+      id: 'tag-monitor',
+      label: 'Monitor',
+      color: '#9C27B0',
+      favorite: false,
+    },
+  ];
+
+  const orderKeys = [
+    'priority-high',
+    'priority-medium',
+    'priority-low',
+    'list-ideas',
+    'list-backlog',
+    'list-inprogress',
+    'list-done',
+    'day-todo',
+    'day-doing',
+    'day-done',
+  ];
+
+  const order = orderKeys.reduce<Record<string, string[]>>((acc, key) => {
+    acc[key] = [];
+    return acc;
+  }, {});
+
+  tasks.forEach(task => {
+    order[`priority-${task.priority}`].push(task.id);
+    order[`list-${task.listId}`].push(task.id);
+    if (task.plannedFor) {
+      const dayKey = `day-${task.dayStatus ?? 'todo'}`;
+      order[dayKey]?.push(task.id);
+    }
+  });
+
+  return {
+    tasks,
+    lists: DEFAULT_LISTS.map(list => ({ ...list })),
+    tags,
+    order,
+    notifications: [],
+    timers: {},
+    mainMyDayTaskId: null,
+    workSchedule: createEmptyWorkSchedule(),
+    workPreferences: {
+      planningReminder: {
+        enabled: false,
+        minutesBefore: 15,
+        lastNotifiedDate: null,
+      },
+    },
+    version: 10,
+  };
+};
+
+export const DEMO_TEMPLATES: DemoTemplate[] = [
+  {
+    id: 'tech-lead-demo-template',
+    roleKey: 'techLead',
+    createState: createTechLeadTemplateState,
+  },
+];

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -196,8 +196,24 @@ const translations: Record<Language, any> = {
       about: 'About',
       openSource: 'Open Source',
       faqs: 'FAQs & Support',
+      demoTemplates: 'Demo templates',
       privacy: 'Privacy Policy',
       terms: 'Terms of Service',
+    },
+    demoTemplatesPage: {
+      title: 'Demo Templates',
+      intro:
+        'Import these incredible examples of how different professionals can use Local Quick Planner.',
+      confirmExisting:
+        'You already have tasks or filters saved. Importing a demo template will replace your current data. Export a backup if you do not want to lose your progress. Continue?',
+      roles: {
+        techLead: {
+          title: 'Technical Lead',
+          description:
+            'As a Technical Lead you coordinate incidents, code reviews, system monitoring, and long-term initiatives while keeping the team aligned.',
+          importCta: 'Import demo template',
+        },
+      },
     },
     aboutPage: {
       title: 'About Local Quick Planner',
@@ -507,8 +523,24 @@ const translations: Record<Language, any> = {
       about: 'Acerca de',
       openSource: 'Código abierto',
       faqs: 'Preguntas frecuentes y soporte',
+      demoTemplates: 'Plantillas demo',
       privacy: 'Política de privacidad',
       terms: 'Términos del servicio',
+    },
+    demoTemplatesPage: {
+      title: 'Plantillas demo',
+      intro:
+        'Importa estos ejemplos increíbles de cómo diferentes profesionales pueden usar Local Quick Planner.',
+      confirmExisting:
+        'Ya tienes tareas o filtros guardados. Importar una plantilla demo reemplazará tus datos actuales. Exporta una copia de seguridad si no quieres perder tu progreso. ¿Quieres continuar?',
+      roles: {
+        techLead: {
+          title: 'Líder Técnico',
+          description:
+            'Como Líder Técnico necesitas organizar incidencias, revisar código, monitorizar sistemas y coordinar iniciativas para mantener al equipo alineado.',
+          importCta: 'Importar plantilla demo',
+        },
+      },
     },
     aboutPage: {
       title: 'Acerca de Local Quick Planner',

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -206,6 +206,11 @@ const translations: Record<Language, any> = {
         'Import these incredible examples of how different professionals can use Local Quick Planner.',
       confirmExisting:
         'You already have tasks or filters saved. Importing a demo template will replace your current data. Export a backup if you do not want to lose your progress. Continue?',
+      successTitle: 'Demo template imported successfully',
+      successDescription:
+        'Your workspace has been populated with demo data. Explore the tasks to see how Local Quick Planner supports this role.',
+      successRoleLabel: 'Role demo:',
+      viewDemoCta: 'View demo',
       roles: {
         techLead: {
           title: 'Technical Lead',
@@ -533,6 +538,11 @@ const translations: Record<Language, any> = {
         'Importa estos ejemplos increíbles de cómo diferentes profesionales pueden usar Local Quick Planner.',
       confirmExisting:
         'Ya tienes tareas o filtros guardados. Importar una plantilla demo reemplazará tus datos actuales. Exporta una copia de seguridad si no quieres perder tu progreso. ¿Quieres continuar?',
+      successTitle: 'Plantilla demo importada correctamente',
+      successDescription:
+        'Hemos rellenado tu espacio de trabajo con datos demo. Explora las tareas para ver cómo Local Quick Planner ayuda a este rol.',
+      successRoleLabel: 'Rol de la demo:',
+      viewDemoCta: 'Ver demo',
       roles: {
         techLead: {
           title: 'Líder Técnico',


### PR DESCRIPTION
## Summary
- add footer link and i18n strings for the new Demo Templates entry
- create the Demo Templates page with a confirmation flow before importing demo data
- provide a technical lead demo template populated with English tasks, tags, and weekly repeats

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db572d3b7c832cb86156ee24117a07