### PR TITLE
Add welcome notification install and demo actions

### DIFF
--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { Info, AlertTriangle, Lightbulb, X } from 'lucide-react';
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import {
+  Info,
+  AlertTriangle,
+  Lightbulb,
+  MonitorSmartphone,
+  LayoutTemplate,
+  X,
+} from 'lucide-react';
 import { useI18n } from '../../lib/i18n';
 import { Notification } from '../../lib/types';
 import { useStore } from '../../lib/store';
 import { getNotificationIconClasses } from '../../lib/notifications';
+import { usePwaInstallPrompt } from '../../lib/usePwaInstallPrompt';
 
 interface Props {
   notification: Notification;
@@ -13,6 +23,7 @@ interface Props {
 export default function NotificationCard({ notification }: Props) {
   const { t } = useI18n();
   const removeNotification = useStore(state => state.removeNotification);
+  const { canInstall, isInstalled, promptInstall } = usePwaInstallPrompt();
   const Icon =
     notification.type === 'alert'
       ? AlertTriangle
@@ -23,6 +34,74 @@ export default function NotificationCard({ notification }: Props) {
   const description =
     notification.description ?? t(notification.descriptionKey);
   const dismissLabel = t('notifications.dismiss');
+  const actions: { key: string; node: ReactNode }[] = [];
+  const installDisabled = isInstalled || !canInstall;
+  const installTitle = isInstalled
+    ? t('notifications.welcome.installInstalled')
+    : !canInstall
+      ? t('notifications.welcome.installUnavailable')
+      : undefined;
+
+  if (notification.id === 'welcome') {
+    actions.push({
+      key: 'install',
+      node: (
+        <button
+          type="button"
+          onClick={() => {
+            if (!installDisabled) {
+              void promptInstall();
+            }
+          }}
+          disabled={installDisabled}
+          title={installTitle}
+          className={`inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 ${
+            installDisabled
+              ? 'cursor-not-allowed opacity-60 hover:bg-emerald-600'
+              : 'hover:bg-emerald-500'
+          }`}
+        >
+          <MonitorSmartphone
+            className="h-4 w-4"
+            aria-hidden="true"
+          />
+          {t('notifications.welcome.installCta')}
+        </button>
+      ),
+    });
+
+    actions.push({
+      key: 'demo',
+      node: (
+        <Link
+          href="/demo-templates"
+          className="inline-flex items-center gap-2 rounded-full bg-gray-200 px-4 py-1.5 text-sm font-semibold text-gray-900 transition hover:bg-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:outline-gray-600"
+        >
+          <LayoutTemplate
+            className="h-4 w-4"
+            aria-hidden="true"
+          />
+          {t('notifications.welcome.demoCta')}
+        </Link>
+      ),
+    });
+  }
+
+  if (notification.actionUrl && notification.actionLabelKey) {
+    actions.push({
+      key: 'action',
+      node: (
+        <a
+          href={notification.actionUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex max-w-full flex-wrap break-words rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          {t(notification.actionLabelKey)}
+        </a>
+      ),
+    });
+  }
 
   return (
     <div className="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-700/60">
@@ -50,15 +129,17 @@ export default function NotificationCard({ notification }: Props) {
           <p className="text-base leading-relaxed text-gray-700 break-words dark:text-gray-200">
             {description}
           </p>
-          {notification.actionUrl && notification.actionLabelKey && (
-            <a
-              href={notification.actionUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex max-w-full flex-wrap break-words rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-            >
-              {t(notification.actionLabelKey)}
-            </a>
+          {actions.length > 0 && (
+            <div className="flex flex-wrap justify-end gap-2">
+              {actions.map(action => (
+                <span
+                  key={action.key}
+                  className="inline-flex"
+                >
+                  {action.node}
+                </span>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -130,7 +130,7 @@ export default function NotificationCard({ notification }: Props) {
             {description}
           </p>
           {actions.length > 0 && (
-            <div className="flex flex-wrap justify-end gap-2">
+            <div className="mt-3 flex flex-wrap justify-end gap-2">
               {actions.map(action => (
                 <span
                   key={action.key}

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -41,8 +41,28 @@ export default function NotificationCard({ notification }: Props) {
     : !canInstall
       ? t('notifications.welcome.installUnavailable')
       : undefined;
+  const primaryActionClasses =
+    'inline-flex items-center justify-center gap-2 rounded bg-[#57886C] px-3 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus:outline-none focus:ring focus:ring-offset-2 focus:ring-[#57886C] disabled:cursor-not-allowed disabled:opacity-60';
+  const secondaryActionClasses =
+    'inline-flex items-center justify-center gap-2 rounded bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 transition hover:bg-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:outline-gray-600';
 
   if (notification.id === 'welcome') {
+    actions.push({
+      key: 'demo',
+      node: (
+        <Link
+          href="/demo-templates"
+          className={secondaryActionClasses}
+        >
+          <LayoutTemplate
+            className="h-4 w-4"
+            aria-hidden="true"
+          />
+          {t('notifications.welcome.demoCta')}
+        </Link>
+      ),
+    });
+
     actions.push({
       key: 'install',
       node: (
@@ -55,11 +75,7 @@ export default function NotificationCard({ notification }: Props) {
           }}
           disabled={installDisabled}
           title={installTitle}
-          className={`inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 ${
-            installDisabled
-              ? 'cursor-not-allowed opacity-60 hover:bg-emerald-600'
-              : 'hover:bg-emerald-500'
-          }`}
+          className={primaryActionClasses}
         >
           <MonitorSmartphone
             className="h-4 w-4"
@@ -67,22 +83,6 @@ export default function NotificationCard({ notification }: Props) {
           />
           {t('notifications.welcome.installCta')}
         </button>
-      ),
-    });
-
-    actions.push({
-      key: 'demo',
-      node: (
-        <Link
-          href="/demo-templates"
-          className="inline-flex items-center gap-2 rounded-full bg-gray-200 px-4 py-1.5 text-sm font-semibold text-gray-900 transition hover:bg-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:outline-gray-600"
-        >
-          <LayoutTemplate
-            className="h-4 w-4"
-            aria-hidden="true"
-          />
-          {t('notifications.welcome.demoCta')}
-        </Link>
       ),
     });
   }

--- a/components/NotificationCard/__tests__/NotificationCard.test.tsx
+++ b/components/NotificationCard/__tests__/NotificationCard.test.tsx
@@ -4,7 +4,7 @@ import NotificationCard from '../NotificationCard';
 import { useStore } from '../../../lib/store';
 
 const baseNotification = {
-  id: 'n1',
+  id: 'welcome',
   type: 'info' as const,
   titleKey: 'notifications.welcome.title',
   descriptionKey: 'notifications.welcome.description',
@@ -49,6 +49,15 @@ describe('NotificationCard', () => {
     expect(link).toHaveAttribute('href', 'https://example.com');
   });
 
+  it('shows welcome quick actions', () => {
+    render(<NotificationCard notification={baseNotification} />);
+
+    expect(screen.getByRole('button', { name: /install app/i })).toBeDisabled();
+    expect(
+      screen.getByRole('link', { name: /explore demo templates/i })
+    ).toHaveAttribute('href', '/demo-templates');
+  });
+
   it('allows dismissing the notification', async () => {
     const user = userEvent.setup();
     render(<NotificationCard notification={baseNotification} />);
@@ -59,6 +68,6 @@ describe('NotificationCard', () => {
 
     await user.click(dismissButton);
 
-    expect(removeNotificationMock).toHaveBeenCalledWith('n1');
+    expect(removeNotificationMock).toHaveBeenCalledWith('welcome');
   });
 });

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -137,6 +137,11 @@ const translations: Record<Language, any> = {
         title: 'Welcome to Local Quick Planner',
         description:
           'Use the "My Tasks" board to collect and prioritize everything you need to do. Move items into "My Day" when you are ready to focus on them. Open settings to switch theme, export your data and more.',
+        installCta: 'Install app',
+        installUnavailable:
+          'Install is only available in supported browsers. Try using the browser menu to add Local Quick Planner to your device.',
+        installInstalled: 'App already installed',
+        demoCta: 'Explore demo templates',
       },
       workReminder: {
         title: 'Plan tomorrow',
@@ -468,6 +473,11 @@ const translations: Record<Language, any> = {
         title: '¡Hola! Te damos la bienvenida a Local Quick Planner',
         description:
           'Usa el tablero "Mis Tareas" para reunir y priorizar todo lo que debes hacer. Pasa los elementos a "Mi Día" cuando quieras enfocarte en ellos. Abre los ajustes para cambiar el tema, exportar tus datos y más.',
+        installCta: 'Instalar app',
+        installUnavailable:
+          'La instalación solo está disponible en navegadores compatibles. Usa el menú del navegador para añadir Local Quick Planner a tu dispositivo.',
+        installInstalled: 'La app ya está instalada',
+        demoCta: 'Ver plantillas de demostración',
       },
       workReminder: {
         title: 'Planifica el mañana',

--- a/lib/usePwaInstallPrompt.ts
+++ b/lib/usePwaInstallPrompt.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+};
+
+export function usePwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const checkInstalled = () => {
+      const mediaQuery = window.matchMedia?.('(display-mode: standalone)');
+      if (mediaQuery?.matches) {
+        setIsInstalled(true);
+        return;
+      }
+
+      if (
+        'standalone' in window.navigator &&
+        (window.navigator as unknown as { standalone?: boolean }).standalone
+      ) {
+        setIsInstalled(true);
+      }
+    };
+
+    checkInstalled();
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      setDeferredPrompt(null);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener(
+        'beforeinstallprompt',
+        handleBeforeInstallPrompt
+      );
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) {
+      return false;
+    }
+
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+
+    if (outcome === 'accepted') {
+      setDeferredPrompt(null);
+      setIsInstalled(true);
+      return true;
+    }
+
+    return false;
+  }, [deferredPrompt]);
+
+  return {
+    isInstalled,
+    canInstall: !isInstalled && deferredPrompt !== null,
+    promptInstall,
+  };
+}


### PR DESCRIPTION
## Summary
- add dedicated install and demo quick actions to the welcome notification card
- introduce a PWA install prompt hook and translations for the new labels

## Testing
- npm run lint
- npm run test -- NotificationCard

------
https://chatgpt.com/codex/tasks/task_e_68db65642af4832c9ca9e7da52554c0d