### PR TITLE
Fix confirmation modal z-index on My Day view

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -389,7 +389,7 @@ export default function Header() {
         </div>
       )}
       {showConfirm && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">
             <p className="mb-4">{t('confirmDelete.message')}</p>
             <div className="flex justify-center gap-2">

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -83,7 +83,7 @@ export default function TasksView() {
         isFiltering={isFiltering}
       />
       {tagToRemove && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">
             <p className="mb-4">{t('tagFilter.confirmDelete')}</p>
             <div className="flex justify-center gap-2">


### PR DESCRIPTION
## Summary
- ensure the delete-all confirmation modal renders above board content by raising its overlay z-index
- align the tag removal confirmation modal overlay z-index to avoid being obscured by tasks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db65b0c35c832c890dad1c27ea75e3