### PR TITLE
Add export warning modal before importing demo templates

### DIFF
--- a/app/demo-templates/page.tsx
+++ b/app/demo-templates/page.tsx
@@ -9,15 +9,20 @@ import { useStore } from '../../lib/store';
 export default function DemoTemplatesPage() {
   const { t } = useI18n();
   const router = useRouter();
-  const { tasks, tags, importData } = useStore(state => ({
+  const { tasks, tags, importData, exportData } = useStore(state => ({
     tasks: state.tasks,
     tags: state.tags,
     importData: state.importData,
+    exportData: state.exportData,
   }));
   const [importedTemplateId, setImportedTemplateId] = useState<string | null>(
     null
   );
   const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showExistingDataModal, setShowExistingDataModal] = useState(false);
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
+    null
+  );
 
   const importedTemplate = useMemo(() => {
     if (!importedTemplateId) {
@@ -34,24 +39,29 @@ export default function DemoTemplatesPage() {
     return t(roleTitleKey);
   }, [importedTemplate, t]);
 
-  const handleImportTemplate = (templateId: string) => {
+  const importTemplate = (templateId: string) => {
     const template = DEMO_TEMPLATES.find(item => item.id === templateId);
     if (!template) {
       return;
     }
 
-    const hasExistingData = tasks.length > 0 || tags.length > 0;
-    if (hasExistingData) {
-      const proceed = window.confirm(t('demoTemplatesPage.confirmExisting'));
-      if (!proceed) {
-        return;
-      }
-    }
-
     const nextState = template.createState();
     importData(nextState);
+    setPendingTemplateId(null);
+    setShowExistingDataModal(false);
     setImportedTemplateId(template.id);
     setShowSuccessModal(true);
+  };
+
+  const handleImportTemplate = (templateId: string) => {
+    const hasExistingData = tasks.length > 0 || tags.length > 0;
+    if (hasExistingData) {
+      setPendingTemplateId(templateId);
+      setShowExistingDataModal(true);
+      return;
+    }
+
+    importTemplate(templateId);
   };
 
   return (
@@ -124,6 +134,54 @@ export default function DemoTemplatesPage() {
                 className="inline-flex items-center justify-center rounded-lg bg-[#57886C] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-[#57886C] dark:focus-visible:ring-offset-gray-900"
               >
                 {t('demoTemplatesPage.viewDemoCta')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showExistingDataModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900"
+          >
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {t('demoTemplatesPage.confirmExistingTitle')}
+            </h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+              {t('demoTemplatesPage.confirmExistingDescription')}
+            </p>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowExistingDataModal(false);
+                  setPendingTemplateId(null);
+                }}
+                className="inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900"
+              >
+                {t('actions.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (pendingTemplateId) {
+                    importTemplate(pendingTemplateId);
+                  }
+                }}
+                className="inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900"
+              >
+                {t('demoTemplatesPage.confirmExistingContinueCta')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  exportData();
+                }}
+                className="inline-flex items-center justify-center rounded-lg bg-[#57886C] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#57886C] focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-[#57886C] dark:focus-visible:ring-offset-gray-900"
+              >
+                {t('demoTemplatesPage.confirmExistingExportCta')}
               </button>
             </div>
           </div>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -28,6 +28,7 @@ const translations: Record<Language, any> = {
       favoriteTag: 'Add tag to favorites',
       unfavoriteTag: 'Remove tag from favorites',
       close: 'Close',
+      cancel: 'Cancel',
       notifications: 'Notifications',
     },
     confirmDelete: {
@@ -209,8 +210,11 @@ const translations: Record<Language, any> = {
       title: 'Demo Templates',
       intro:
         'Import these incredible examples of how different professionals can use CheckPlanner.',
-      confirmExisting:
-        'You already have tasks or filters saved. Importing a demo template will replace your current data. Export a backup if you do not want to lose your progress. Continue?',
+      confirmExistingTitle: 'Back up your tasks before importing',
+      confirmExistingDescription:
+        'You already have tasks or filters saved. Importing a demo template will replace your current data. Export your tasks first to avoid losing progress. In Settings you will find options to Export, Import, or Delete everything.',
+      confirmExistingExportCta: 'Export tasks',
+      confirmExistingContinueCta: 'Import demo anyway',
       successTitle: 'Demo template imported successfully',
       successDescription:
         'Your workspace has been populated with demo data. Explore the tasks to see how CheckPlanner supports this role.',
@@ -389,6 +393,7 @@ const translations: Record<Language, any> = {
       favoriteTag: 'Marcar etiqueta como favorita',
       unfavoriteTag: 'Quitar etiqueta de favoritas',
       close: 'Cerrar',
+      cancel: 'Cancelar',
       notifications: 'Notificaciones',
     },
     confirmDelete: {
@@ -572,8 +577,11 @@ const translations: Record<Language, any> = {
       title: 'Plantillas demo',
       intro:
         'Importa estos ejemplos increíbles de cómo diferentes profesionales pueden usar CheckPlanner.',
-      confirmExisting:
-        'Ya tienes tareas o filtros guardados. Importar una plantilla demo reemplazará tus datos actuales. Exporta una copia de seguridad si no quieres perder tu progreso. ¿Quieres continuar?',
+      confirmExistingTitle: 'Respalda tus tareas antes de importar',
+      confirmExistingDescription:
+        'Ya tienes tareas o filtros guardados. Importar una plantilla demo reemplazará tus datos actuales. Exporta tus tareas para no perder tu progreso. En Ajustes encontrarás las opciones de Exportar, Importar y Eliminar todo.',
+      confirmExistingExportCta: 'Exportar tareas',
+      confirmExistingContinueCta: 'Importar demo igualmente',
       successTitle: 'Plantilla demo importada correctamente',
       successDescription:
         'Hemos rellenado tu espacio de trabajo con datos demo. Explora las tareas para ver cómo CheckPlanner ayuda a este rol.',


### PR DESCRIPTION
## Summary
- show a confirmation modal when importing demo templates with existing data
- add actions to export tasks or continue importing after reviewing the warning
- update i18n strings for the new modal content in English and Spanish

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df509be9e0832ca2fc9282c17238e7